### PR TITLE
エラーログ保存機能の追加と投資信託戦略のタイムアウト改善

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
 		"CHROMIUM_USER_DATA_DIR_MATSUI": "/workspaces/zaim-matsui-auto-sync/appdata/chromium/matsui",
 		"ZAIM_ACCESS_TOKEN_FILE": "/workspaces/zaim-matsui-auto-sync/appdata/zaim/zaim-tokens.json",
 		"ZAIM_TOTAL_AMOUNT_FILE": "/workspaces/zaim-matsui-auto-sync/appdata/zaim/zaim-total-amount.json",
+		"ERROR_LOG_DIR": "/workspaces/zaim-matsui-auto-sync/appdata/error-logs",
 		"CONFIG_FILE": "/workspaces/zaim-matsui-auto-sync/config.json"
 	},
 

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,8 @@ appdata/chromium/*
 !appdata/chromium/.gitkeep
 appdata/zaim/*
 !appdata/zaim/zaim-total-amount.example.json
+appdata/error-logs/*
+!appdata/error-logs/.gitkeep
 
 # Docker Compose override file
 compose.override.yaml

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@ services:
       CHROMIUM_USER_DATA_DIR_MATSUI: /home/appuser/.config/appdata/chromium/matsui
       ZAIM_ACCESS_TOKEN_FILE: /home/appuser/.config/appdata/zaim/zaim-tokens.json
       ZAIM_TOTAL_AMOUNT_FILE: /home/appuser/.config/appdata/zaim/zaim-total-amount.json
+      ERROR_LOG_DIR: /home/appuser/.config/appdata/error-logs
       CONFIG_FILE: /home/appuser/.config/appdata/config.json
     env_file:
       - .env
@@ -25,6 +26,10 @@ services:
       - type: bind
         source: ./appdata/zaim
         target: /home/appuser/.config/appdata/zaim
+        consistency: consistent
+      - type: bind
+        source: ./appdata/error-logs
+        target: /home/appuser/.config/appdata/error-logs
         consistency: consistent
       - type: bind
         source: ./config.json

--- a/src/modules/matsui/scraper.ts
+++ b/src/modules/matsui/scraper.ts
@@ -13,6 +13,13 @@ export class MatsuiScraper {
   private page: Page | null = null;
 
   /**
+   * 現在のページオブジェクトを取得
+   */
+  get currentPage(): Page | null {
+    return this.page;
+  }
+
+  /**
    * ブラウザを初期化してCookieを復元
    */
   async initialize(): Promise<void> {

--- a/src/modules/matsui/strategies/fund-strategy.ts
+++ b/src/modules/matsui/strategies/fund-strategy.ts
@@ -25,9 +25,9 @@ export class FundStrategy implements AssetScrapingStrategy<Position> {
       }
 
       try {
-        // モーダルが表示されるまで待機（最大3秒）
+        // モーダルが表示されるまで待機（最大10秒）
         await page.waitForSelector(".modal-container.dialog.error", {
-          timeout: 3000,
+          timeout: 10000,
           state: "visible",
         });
       } catch {

--- a/src/modules/sync/sync-service.ts
+++ b/src/modules/sync/sync-service.ts
@@ -66,7 +66,6 @@ export class MatsuiZaimSyncService {
           // 戦略ごとのエラーをキャプチャ
           await this.captureErrorContext(this.scraper.currentPage, error as Error, {
             strategyType,
-            operation: "認証またはスクレイピング",
           });
           throw error; // 再スロー
         }
@@ -156,12 +155,12 @@ export class MatsuiZaimSyncService {
    *
    * @param page Playwrightのページオブジェクト
    * @param error 発生したエラー
-   * @param context コンテキスト情報（戦略タイプ、実行中の操作など）
+   * @param context コンテキスト情報（戦略タイプ）
    */
   private async captureErrorContext(
     page: Page | null,
     error: Error,
-    context: { strategyType?: string; operation: string }
+    context: { strategyType?: string }
   ): Promise<void> {
     try {
       // ERROR_LOG_DIR が未設定の場合はスキップ


### PR DESCRIPTION
## Summary
- エラー発生時のコンテキスト情報（スクリーンショット、HTML、メタデータ）を自動保存する機能を追加
- 投資信託戦略でのエラーダイアログ待機時間を改善（3秒→10秒）

## 主な変更内容

### エラーログ保存機能
- `sync-service.ts` に `captureErrorContext` メソッドを追加
  - エラー発生時にスクリーンショット、ページHTML、メタデータ（URL、タイムスタンプ、エラー内容）を保存
  - タイムスタンプ付きディレクトリに整理して保存
- `ERROR_LOG_DIR` 環境変数を追加（devcontainer、docker-compose）
- `appdata/error-logs/` ディレクトリを追加（.gitignore設定済み）
- `MatsuiScraper` に `currentPage` ゲッターを追加してページオブジェクトへのアクセスを提供
- 戦略ごとのエラーハンドリングを改善し、エラーキャプチャ後に再スロー

### 投資信託戦略のタイムアウト改善
- `fund-strategy.ts`: エラーダイアログの待機タイムアウトを3秒から10秒に変更
  - より確実にエラーダイアログを検出できるように改善

## Test plan
- [x] エラーログ保存機能の動作確認
  - エラー発生時に `appdata/error-logs/{timestamp}/` ディレクトリが作成されることを確認
  - スクリーンショット、HTML、メタデータが正しく保存されることを確認
- [x] 投資信託戦略のタイムアウト動作確認
  - エラーダイアログが表示される場合に適切に検出されることを確認
- [x] 環境変数の設定確認
  - devcontainer、docker-compose で `ERROR_LOG_DIR` が正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)