### PR TITLE
tagprとGHCRを使った自動リリース機能を追加・Dockerコンテナのユーザー権限管理改善

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@ HEADLESS=false
 LOG_LEVEL=info
 
 # コンテナ実行ユーザーのUID/GID（ホスト側のUID/GIDに合わせる）
-PUID=1000
-PGID=1000
+# PUID=1000
+# PGID=1000
 
 # 松井証券の認証コードを受信するGoogleメッセージ会話のURL
 GOOGLE_MESSAGE_MATSUI_CONVERSATION_URL=https://messages.google.com/web/conversations/*******

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ AUTH_CODE_POLLING_TIMEOUT_SECONDS=60
 # Zaim API認証用のコンシューマーキーとコンシューマーシークレット
 ZAIM_CONSUMER_KEY=
 ZAIM_CONSUMER_SECRET=
+
+# Docker イメージのバージョン指定（指定しない場合は latest を使用）
+# IMAGE_TAG=1.2.3

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 HEADLESS=false
 LOG_LEVEL=info
 
+# コンテナ実行ユーザーのUID/GID（ホスト側のUID/GIDに合わせる）
+PUID=1000
+PGID=1000
+
 # 松井証券の認証コードを受信するGoogleメッセージ会話のURL
 GOOGLE_MESSAGE_MATSUI_CONVERSATION_URL=https://messages.google.com/web/conversations/*******
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
    directory: "/"
    schedule:
      interval: weekly
+
+ - package-ecosystem: "github-actions"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+        - fix
+    - title: Documentation 📝
+      labels:
+        - documentation
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/scripts/create-release.js
+++ b/.github/scripts/create-release.js
@@ -18,11 +18,18 @@ try {
   const releaseNotes = generateNotesResponse.data.body;
   console.log('Release notes generated successfully');
 
-  // Update the release
-  await github.rest.repos.updateRelease({
+  // Find the draft release by tag
+  const { data: release } = await github.rest.repos.getReleaseByTag({
     owner: repo.owner,
     repo: repo.repo,
     tag: tagName,
+  });
+
+  // Update the release to publish it
+  await github.rest.repos.updateRelease({
+    owner: repo.owner,
+    repo: repo.repo,
+    release_id: release.id,
     draft: false,
     make_latest: 'true',
     body: releaseNotes

--- a/.github/scripts/create-release.js
+++ b/.github/scripts/create-release.js
@@ -1,0 +1,44 @@
+const tagName = process.env.TAG_NAME;
+const repo = context.repo;
+
+if (!tagName) {
+  throw new Error('TAG_NAME environment variable is required');
+}
+
+try {
+  console.log(`Generating release notes for tag: ${tagName}`);
+
+  // Generate release notes
+  const generateNotesResponse = await github.rest.repos.generateReleaseNotes({
+    owner: repo.owner,
+    repo: repo.repo,
+    tag_name: tagName
+  });
+
+  const releaseNotes = generateNotesResponse.data.body;
+  console.log('Release notes generated successfully');
+
+  // Update the release
+  await github.rest.repos.updateRelease({
+    owner: repo.owner,
+    repo: repo.repo,
+    tag: tagName,
+    draft: false,
+    make_latest: 'true',
+    body: releaseNotes
+  });
+
+  console.log(`Successfully updated release ${tagName} with generated notes`);
+  console.log('Release is now published and marked as latest');
+} catch (error) {
+  console.error('Error updating release:', error.message);
+
+  // Provide more specific error information
+  if (error.status === 404) {
+    console.error(`Release with tag ${tagName} not found`);
+  } else if (error.status === 403) {
+    console.error('Insufficient permissions to update release');
+  }
+
+  throw error;
+}

--- a/.github/scripts/create-release.js
+++ b/.github/scripts/create-release.js
@@ -18,12 +18,16 @@ try {
   const releaseNotes = generateNotesResponse.data.body;
   console.log('Release notes generated successfully');
 
-  // Find the draft release by tag
-  const { data: release } = await github.rest.repos.getReleaseByTag({
+  // Find the draft release by listing releases and matching the tag
+  const { data: releases } = await github.rest.repos.listReleases({
     owner: repo.owner,
     repo: repo.repo,
-    tag: tagName,
   });
+
+  const release = releases.find(r => r.tag_name === tagName);
+  if (!release) {
+    throw new Error(`Release with tag ${tagName} not found`);
+  }
 
   // Update the release to publish it
   await github.rest.repos.updateRelease({

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -69,3 +69,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  publish-release:
+    needs: [tagpr, docker]
+    if: needs.tagpr.outputs.tag != ''
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Create and publish release
+        uses: actions/github-script@v8
+        with:
+          script-file: .github/scripts/create-release.js
+        env:
+          TAG_NAME: ${{ needs.tagpr.outputs.tag }}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.tagpr.outputs.tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run tagpr
+        id: tagpr
+        uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    needs: tagpr
+    if: needs.tagpr.outputs.tag != ''
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.tagpr.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.tagpr.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ needs.tagpr.outputs.tag }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,6 @@
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = package.json
+	changelog = true
+	release = true

--- a/.tagpr
+++ b/.tagpr
@@ -3,4 +3,4 @@
 	releaseBranch = main
 	versionFile = package.json
 	changelog = true
-	release = true
+	release = draft

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ FROM node:22-bookworm-slim
 
 WORKDIR /app
 
-ARG UID=1000
-ARG GID=1000
-
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
@@ -28,10 +25,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         tigervnc-common \
         dbus-x11
 
-RUN if getent passwd $UID; then deluser $(getent passwd $UID | cut -d: -f1); fi && \
-    if getent group $GID; then delgroup $(getent group $GID | cut -d: -f1); fi && \
-    groupadd -g $GID appuser && \
-    useradd -u $UID -g $GID -m appuser && \
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g 1000 -m appuser && \
     mkdir -p /etc/sudoers.d && \
     echo 'appuser ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/appuser && \
     chmod 0440 /etc/sudoers.d/appuser && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         tigervnc-common \
         dbus-x11
 
-RUN groupadd -g 1000 appuser && \
-    useradd -u 1000 -g 1000 -m appuser && \
-    mkdir -p /etc/sudoers.d && \
-    echo 'appuser ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/appuser && \
-    chmod 0440 /etc/sudoers.d/appuser && \
-    chown -R appuser:appuser .
-    
-USER appuser
+RUN mkdir -p /etc/sudoers.d && \
+    echo 'node ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/node && \
+    chmod 0440 /etc/sudoers.d/node && \
+    chown -R node:node .
 
-COPY --from=builder --chown=appuser:appuser /app/dist ./dist
-COPY --from=builder --chown=appuser:appuser /app/package*.json ./
+USER node
+
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/package*.json ./
 
 RUN npm ci --omit=dev --ignore-scripts && \
     npx playwright install --with-deps --no-shell chromium && \
@@ -45,8 +43,8 @@ RUN npm ci --omit=dev --ignore-scripts && \
     sudo rm -rf \
         /opt/yarn-* \
         /tmp/* \
-        /home/appuser/.cache/ms-playwright/ffmpeg* \
-        /home/appuser/.npm/_logs/*
+        /home/node/.cache/ms-playwright/ffmpeg* \
+        /home/node/.npm/_logs/*
 
 COPY --chmod=755 entrypoint.sh /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,7 @@ RUN if getent passwd $UID; then deluser $(getent passwd $UID | cut -d: -f1); fi 
     useradd -u $UID -g $GID -m appuser && \
     mkdir -p /etc/sudoers.d && \
     echo 'appuser ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/appuser && \
-    echo 'ALL ALL=(ALL) NOPASSWD: /usr/bin/chown' >> /etc/sudoers.d/chown-for-uid-override && \
-    chmod 0440 /etc/sudoers.d/appuser /etc/sudoers.d/chown-for-uid-override && \
+    chmod 0440 /etc/sudoers.d/appuser && \
     chown -R appuser:appuser .
     
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN if getent passwd $UID; then deluser $(getent passwd $UID | cut -d: -f1); fi 
     useradd -u $UID -g $GID -m appuser && \
     mkdir -p /etc/sudoers.d && \
     echo 'appuser ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/appuser && \
-    chmod 0440 /etc/sudoers.d/appuser && \
+    echo 'ALL ALL=(ALL) NOPASSWD: /usr/bin/chown' >> /etc/sudoers.d/chown-for-uid-override && \
+    chmod 0440 /etc/sudoers.d/appuser /etc/sudoers.d/chown-for-uid-override && \
     chown -R appuser:appuser .
     
 USER appuser

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ docker compose run --rm -e APP_COMMAND='sync-matsui-zaim' -e APP_ARGS='--dry-run
 
 1. 下記のコマンドで Chromium を起動する。
     ```bash
-    $(find ~/.cache/ms-playwright/ -executable -name chrome) --no-sandbox --user-data-dir=./appdata/chromium/google https://www.google.com
+    $(find ~/.cache/ms-playwright/ -executable -name chrome -print -quit) --no-sandbox --user-data-dir=./appdata/chromium/google https://www.google.com
     ```
 2. 手動操作で Google にログインする。
 3. ログイン後、https://messages.google.com/web/ に遷移してデバイスのペア設定を行う。

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ docker compose run --rm -e APP_COMMAND='sync-matsui-zaim' -e APP_ARGS='--dry-run
 
 1. 下記のコマンドで Chromium を起動する。
     ```bash
-    ~/.cache/ms-playwright/chromium-1181/chrome-linux/chrome --no-sandbox --user-data-dir=./appdata/chromium/google https://www.google.com
+    $(find ~/.cache/ms-playwright/ -executable -name chrome) --no-sandbox --user-data-dir=./appdata/chromium/google https://www.google.com
     ```
 2. 手動操作で Google にログインする。
 3. ログイン後、https://messages.google.com/web/ に遷移してデバイスのペア設定を行う。

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,12 +3,12 @@ services:
     image: ghcr.io/na3shkw/zaim-matsui-auto-sync:${IMAGE_TAG:-latest}
     environment:
       NODE_ENV: production
-      CHROMIUM_USER_DATA_DIR_GOOGLE: /home/appuser/.config/appdata/chromium/google
-      CHROMIUM_USER_DATA_DIR_MATSUI: /home/appuser/.config/appdata/chromium/matsui
-      ZAIM_ACCESS_TOKEN_FILE: /home/appuser/.config/appdata/zaim/zaim-tokens.json
-      ZAIM_TOTAL_AMOUNT_FILE: /home/appuser/.config/appdata/zaim/zaim-total-amount.json
-      ERROR_LOG_DIR: /home/appuser/.config/appdata/error-logs
-      CONFIG_FILE: /home/appuser/.config/appdata/config.json
+      CHROMIUM_USER_DATA_DIR_GOOGLE: /home/node/.config/appdata/chromium/google
+      CHROMIUM_USER_DATA_DIR_MATSUI: /home/node/.config/appdata/chromium/matsui
+      ZAIM_ACCESS_TOKEN_FILE: /home/node/.config/appdata/zaim/zaim-tokens.json
+      ZAIM_TOTAL_AMOUNT_FILE: /home/node/.config/appdata/zaim/zaim-total-amount.json
+      ERROR_LOG_DIR: /home/node/.config/appdata/error-logs
+      CONFIG_FILE: /home/node/.config/appdata/config.json
     env_file:
       - .env
     security_opt:
@@ -16,18 +16,18 @@ services:
     volumes:
       - type: volume
         source: chromium-data
-        target: /home/appuser/.config/appdata/chromium
+        target: /home/node/.config/appdata/chromium
       - type: bind
         source: ./appdata/zaim
-        target: /home/appuser/.config/appdata/zaim
+        target: /home/node/.config/appdata/zaim
         consistency: consistent
       - type: bind
         source: ./appdata/error-logs
-        target: /home/appuser/.config/appdata/error-logs
+        target: /home/node/.config/appdata/error-logs
         consistency: consistent
       - type: bind
         source: ./config.json
-        target: /home/appuser/.config/appdata/config.json
+        target: /home/node/.config/appdata/config.json
         consistency: consistent
     network_mode: "host"
     init: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
       - .env
     security_opt:
       - seccomp:./seccomp-profile.json
-    user: appuser:appuser
+    user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - type: volume
         source: chromium-data

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,6 @@
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        UID: ${UID:-1000}
-        GID: ${GID:-1000}
+    image: ghcr.io/na3shkw/zaim-matsui-auto-sync:${IMAGE_TAG:-latest}
     environment:
       NODE_ENV: production
       CHROMIUM_USER_DATA_DIR_GOOGLE: /home/appuser/.config/appdata/chromium/google

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,6 @@ services:
       - .env
     security_opt:
       - seccomp:./seccomp-profile.json
-    user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - type: volume
         source: chromium-data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ if [ -z "$APP_COMMAND" ]; then
     exit 1
 fi
 
-sudo chown -R appuser:appuser ~/.config
+sudo chown -R "$(id -u):$(id -g)" /home/appuser/.config 2>/dev/null || true
 
 # VNCサーバーを起動する
 if [[ "$ENABLE_VNC" = "1" || "$APP_COMMAND" = "login-google" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ show_usage() {
     echo "                          zaim-cli"
     echo "                          login-google"
     echo "  APP_ARGS             - コマンドに渡すオプション/引数"
+    echo "  PUID                 - マウントされたファイルの所有者UID（デフォルト: 設定なし＝変更しない）"
+    echo "  PGID                 - マウントされたファイルの所有者GID（デフォルト: 設定なし＝変更しない）"
     echo "  ENABLE_VNC=1         - VNCサーバーを起動する"
     echo "  VNC_GEOMETRY         - VNCサーバーの解像度を設定する（デフォルト1280x960）"
 }
@@ -19,7 +21,11 @@ if [ -z "$APP_COMMAND" ]; then
     exit 1
 fi
 
-sudo chown -R "$(id -u):$(id -g)" /home/appuser/.config 2>/dev/null || true
+# PUID/PGIDが指定されている場合、マウントされたファイルの所有者を変更する
+if [ -n "$PUID" ] || [ -n "$PGID" ]; then
+    OWNER="${PUID:-$(id -u)}:${PGID:-$(id -g)}"
+    sudo chown -R "$OWNER" /home/appuser/.config
+fi
 
 # VNCサーバーを起動する
 if [[ "$ENABLE_VNC" = "1" || "$APP_COMMAND" = "login-google" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ case "$APP_COMMAND" in
         exec gosu node ./dist/commands/zaim/index.js "$@"
         ;;
     "login-google")
-        chromium=$(find /home/node/.cache/ms-playwright/ -executable -name chrome)
+        chromium=$(find /home/node/.cache/ms-playwright/ -executable -name chrome -print -quit)
         exec gosu node "$chromium" \
             --user-data-dir="$CHROMIUM_USER_DATA_DIR_GOOGLE" \
             "$@"


### PR DESCRIPTION
## 概要

tagprとGHCR（GitHub Container Registry）を使用した自動リリース機能の実装、およびDockerコンテナのユーザー権限管理を改善しました。

## 変更内容

### 自動リリース機能

#### tagpr設定 (`.tagpr`)
- mainブランチへのマージを監視し、自動的にバージョンアップPRを作成
- package.jsonのバージョンを管理
- CHANGELOG.mdを自動生成
- ドラフトリリースを作成（後続のワークフローで自動公開）

#### ラベルベースのリリースノート設定 (`.github/release.yml`)
- PRのラベルに基づいて変更内容を自動分類
  - 🛠 Breaking Changes (`breaking-change`)
  - 🎉 New Features (`enhancement`, `feature`)
  - 🐛 Bug Fixes (`bug`, `fix`)
  - 📝 Documentation (`documentation`, `docs`)
  - その他の変更
- tagprラベルの付いたPRは除外

#### リリース公開スクリプト (`.github/scripts/create-release.js`)
- GitHub APIを使用してリリースノートを自動生成
- `listReleases` APIでドラフトリリースを確実に取得し、自動的に公開
- `.github/release.yml`の設定に基づいて分類されたリリースノートを生成

#### リリースワークフロー (`.github/workflows/tagpr.yml`)
- **tagprジョブ**: バージョン管理とドラフトリリース作成
- **dockerジョブ**: マルチプラットフォームDockerイメージのビルド＆GHCR push
  - 対応プラットフォーム: `linux/amd64`, `linux/arm64`（Raspberry Pi対応）
  - タグ戦略: `v1.2.3` → `1.2.3`, `1.2`, `1`, `latest`
  - GitHub Actions キャッシュで高速化
- **publish-releaseジョブ**: ドラフトリリースを自動公開

#### Dependabot設定 (`.github/dependabot.yml`)
- GitHub Actionsエコシステムの依存関係監視を追加

### Dockerコンテナのユーザー権限管理改善

#### Dockerfile
- `appuser` を廃止し、Node.js公式イメージ組み込みの `node` ユーザーを利用
- `sudo` を `gosu` に置き換え（Dockerコンテナのベストプラクティスに準拠）
- ビルド時の `UID`/`GID` ARGを廃止し、実行時の `PUID`/`PGID` 環境変数で動的に変更する方式に移行
- Playwrightのインストールをrootで実行するように変更（`sudo` 不要に）

#### entrypoint.sh
- `PUID`/`PGID` 環境変数が指定された場合のみ、nodeユーザーのUID/GIDを動的に変更
- 全コマンドを `gosu node` 経由で実行するように変更
- Chromiumのパスをハードコードから `find` による動的検索に変更（`-print -quit` で安定性を確保）
- VNCサーバーも `gosu node` で起動するように変更

#### compose.yaml
- ローカルビルドからGHCRイメージ（`ghcr.io/na3shkw/zaim-matsui-auto-sync`）の使用に変更
- `IMAGE_TAG` 環境変数でバージョン指定可能（デフォルト: `latest`）
- パス参照を `/home/appuser/` から `/home/node/` に統一
- `user: appuser:appuser` を削除（entrypoint.shで `gosu` により制御）

#### .env.example
- `PUID`/`PGID` 変数の例を追加
- `IMAGE_TAG` 変数の例を追加

#### README.md
- Chromiumの起動コマンドをハードコードパスから `find` による動的検索に変更

## リリースフロー

```
PRをmainにマージ
    ↓
tagprがバージョンアップPRを自動作成
（CHANGELOG.mdも自動更新）
    ↓
バージョンPRをマージ
    ↓
自動的にGitタグとドラフトリリースが作成
    ↓
DockerイメージをビルドしGHCRにpush
    ↓
リリースノートを生成してリリースを公開
```

## 使用方法

### デフォルト（latest）
```bash
docker compose pull
docker compose up -d
```

### 特定バージョン
```bash
# .envに追加
IMAGE_TAG=1.2.3

# または
IMAGE_TAG=1.2.3 docker compose pull
```

### UID/GIDの指定（バインドマウントの所有者をホスト側に合わせる場合）
```bash
# .envに追加
PUID=1000
PGID=1000
```

## 重要な注意事項

⚠️ **このPRをマージする前に必須の設定があります**

GitHub設定で以下を有効化してください:
1. Settings → Actions → General
2. "Workflow permissions"セクション
3. **"Allow GitHub Actions to create and approve pull requests"を有効化**

この設定がないとtagprが動作しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)