### PR TITLE
UID/GIDの変更処理を軽量化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN npm ci --omit=dev --ignore-scripts
 
 USER root
 
-ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 RUN npx playwright install --with-deps --no-shell chromium && \
     npm cache clean --force && \
@@ -45,7 +45,7 @@ RUN npx playwright install --with-deps --no-shell chromium && \
     rm -rf \
         /opt/yarn-* \
         /tmp/* \
-        /home/node/.cache/ms-playwright/ffmpeg* \
+        /ms-playwright/ffmpeg* \
         /home/node/.npm/_logs/* && \
     chown -R node:node /home/node
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ docker compose run --rm -e APP_COMMAND='sync-matsui-zaim' -e APP_ARGS='--dry-run
 
 1. 下記のコマンドで Chromium を起動する。
     ```bash
-    $(find ~/.cache/ms-playwright/ -executable -name chrome -print -quit) --no-sandbox --user-data-dir=./appdata/chromium/google https://www.google.com
+    $(find $PLAYWRIGHT_BROWSERS_PATH/ -executable -name chrome -print -quit) --no-sandbox --user-data-dir=./appdata/chromium/google https://www.google.com
     ```
 2. 手動操作で Google にログインする。
 3. ログイン後、https://messages.google.com/web/ に遷移してデバイスのペア設定を行う。

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,8 +27,8 @@ if [ -n "$PUID" ] || [ -n "$PGID" ]; then
     PGID=${PGID:-$(id -g node)}
     if [ "$PGID" != "$(id -g node)" ] || [ "$PUID" != "$(id -u node)" ]; then
         echo "Changing node user UID:GID to $PUID:$PGID"
-        sed -i "s/^node:x:[0-9]*:[0-9]*:/node:x:$PUID:$PGID:/" /etc/passwd
-        sed -i "s/^node:x:[0-9]*:/node:x:$PGID:/" /etc/group
+        groupmod -o -g "$PGID" node
+        usermod -o -u "$PUID" node
         chown -R node:node /home/node/.config
     fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,9 +27,9 @@ if [ -n "$PUID" ] || [ -n "$PGID" ]; then
     PGID=${PGID:-$(id -g node)}
     if [ "$PGID" != "$(id -g node)" ] || [ "$PUID" != "$(id -u node)" ]; then
         echo "Changing node user UID:GID to $PUID:$PGID"
-        groupmod -o -g "$PGID" node
-        usermod -o -u "$PUID" node
-        chown -R node:node /app /home/node
+        sed -i "s/^node:x:[0-9]*:[0-9]*:/node:x:$PUID:$PGID:/" /etc/passwd
+        sed -i "s/^node:x:[0-9]*:/node:x:$PGID:/" /etc/group
+        chown -R node:node /app /home/node/.config
     fi
 fi
 
@@ -50,7 +50,7 @@ case "$APP_COMMAND" in
         exec gosu node ./dist/commands/zaim/index.js "$@"
         ;;
     "login-google")
-        chromium=$(find /home/node/.cache/ms-playwright/ -executable -name chrome -print -quit)
+        chromium=$(find /ms-playwright/ -executable -name chrome -print -quit)
         exec gosu node "$chromium" \
             --user-data-dir="$CHROMIUM_USER_DATA_DIR_GOOGLE" \
             "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ if [ -n "$PUID" ] || [ -n "$PGID" ]; then
         echo "Changing node user UID:GID to $PUID:$PGID"
         sed -i "s/^node:x:[0-9]*:[0-9]*:/node:x:$PUID:$PGID:/" /etc/passwd
         sed -i "s/^node:x:[0-9]*:/node:x:$PGID:/" /etc/group
-        chown -R node:node /app /home/node/.config
+        chown -R node:node /home/node/.config
     fi
 fi
 


### PR DESCRIPTION
## 概要
このPRは、コンテナセットアップをリファクタリングして互換性を向上させ、UID/GIDの変更を簡素化します。Playwrightブラウザキャッシュをnodeユーザーのホームディレクトリからルートレベルのディレクトリに移動します。

## 主な変更点
- **Playwrightブラウザパス**: Dockerfileとentrypointスクリプトの両方で `/home/node/.cache/ms-playwright` から `/ms-playwright` に変更
  - `PLAYWRIGHT_BROWSERS_PATH` 環境変数を更新
  - Dockerfile内のクリーンアップパスを更新
  - login-googleコマンド内のChromium検出パスを更新
- **chownスコープ**: `chown` 対象を `/app /home/node` から `/app /home/node/.config` に限定
  - 不要な権限変更を削減

## 実装詳細
- ブラウザを `/ms-playwright` に移動することで、nodeユーザーのホームディレクトリに関する潜在的な権限問題を回避

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>