### PR TITLE
docs: READMEのVNC接続手順を簡略化

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Google メッセージへのアクセスをスムーズに行うため、事前�
     ```bash
     docker compose run --rm -e APP_COMMAND='login-google' -e APP_ARGS='https://www.google.com' --publish <ホスト側 VNC ポート>:5901 app
     ```
-2. `localhost:<ホスト側 VNC ポート>` に VNC 接続する。接続ユーザーは `appuser` で認証はなし。
+2. `localhost:<ホスト側 VNC ポート>` に VNC 接続する。認証はなし。
 3. 手動操作で Google にログインする。
 4. ログイン後、https://messages.google.com/web/ に遷移してデバイスのペア設定を行う。
 5. Chromium を閉じる。


### PR DESCRIPTION
## 概要
READMEのVNC接続手順から、接続ユーザーに関する冗長な情報を削除しました。

## 変更内容
- VNC設定手順から接続ユーザー `appuser` に関する記述を削除
- ステップ2を簡略化し、必須情報（VNC接続アドレスと認証不要であること）のみに焦点を当てました

## 詳細
この変更により、接続ユーザー（`appuser`）に関する不要な詳細を削除し、接続に必要な情報（アドレスと認証の欠如）のみを保持することで、VNC接続手順を明確化しました。

https://claude.ai/code/session_01TvaA63AwL4AmzwaLCH8HBU