### PR TITLE
attest actionをv4に更新し、新しいアクション名を適用

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -79,7 +79,7 @@ jobs:
           sbom: true
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}
           subject-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## 概要
GitHub Actionsワークフローを更新し、統一された新しい命名規則を持つ最新バージョンのattestationアクションを使用するようにします。

## 変更内容
- `actions/attest-build-provenance@v3` を `actions/attest@v4` に更新
  - これはGitHub Actionsエコシステムにおいて、attestation機能が単一のアクションに統合されたことを反映しています
  - このアクションは既存の `subject-name` と `subject-digest` 入力との後方互換性を維持しています

## 詳細
v4の `actions/attest` アクションは、以前の `actions/attest-build-provenance` アクションと同じビルド来歴証明機能を提供しますが、複数の証明タイプをサポートする統一されたアクション名の下で提供されます。

https://claude.ai/code/session_019Q3CAwZS9VveizzAim13FT