### PR TITLE
クッキー管理をPlaywrightのstorageState APIを使用するようにリファクタリング

### DIFF
--- a/src/modules/matsui/browser.ts
+++ b/src/modules/matsui/browser.ts
@@ -24,8 +24,16 @@ export async function openBrowser(
       // headlessモードで起動した際のクラッシュを回避するため
       "--single-process",
     ],
-    storageState: storageStatePath,
   });
+
+  if (storageStatePath) {
+    const state = JSON.parse(fs.readFileSync(storageStatePath, "utf-8")) as {
+      cookies?: Parameters<BrowserContext["addCookies"]>[0];
+    };
+    if (state.cookies && state.cookies.length > 0) {
+      await browserContext.addCookies(state.cookies);
+    }
+  }
 
   // ランダムに表示されるポップアップスクリプトをブロック
   await browserContext.route(/\/Rtoaster(\.Popup)?\.js(\?.*)?$/, (route) =>

--- a/src/modules/matsui/browser.ts
+++ b/src/modules/matsui/browser.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import type { BrowserContext } from "playwright";
 import { chromium } from "playwright";
+import { logger } from "../logger.js";
 
 /**
  * ユーザーデータディレクトリを指定してブラウザを開く
@@ -27,11 +28,22 @@ export async function openBrowser(
   });
 
   if (storageStatePath) {
-    const state = JSON.parse(fs.readFileSync(storageStatePath, "utf-8")) as {
-      cookies?: Parameters<BrowserContext["addCookies"]>[0];
-    };
-    if (state.cookies && state.cookies.length > 0) {
-      await browserContext.addCookies(state.cookies);
+    // launchPersistentContext は storageState オプションをサポートしないため、
+    // addCookies() で Cookie のみ復元する。
+    // localStorage・sessionStorage はユーザーデータディレクトリのプロファイルに
+    // 残るため、実用上の問題は生じない。
+    try {
+      const state = JSON.parse(fs.readFileSync(storageStatePath, "utf-8")) as {
+        cookies?: Parameters<BrowserContext["addCookies"]>[0];
+      };
+      if (state.cookies && state.cookies.length > 0) {
+        await browserContext.addCookies(state.cookies);
+      }
+    } catch (e) {
+      logger.warn(
+        { err: e },
+        "storage-state.json の読み込みに失敗しました。Cookieなしで続行します。"
+      );
     }
   }
 

--- a/src/modules/matsui/browser.ts
+++ b/src/modules/matsui/browser.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import type { BrowserContext, Page } from "playwright";
+import type { BrowserContext } from "playwright";
 import { chromium } from "playwright";
 
 /**
@@ -8,9 +8,14 @@ import { chromium } from "playwright";
  *
  * @param userDataDir ユーザーデータのあるパス
  * @param headless ヘッドレスで起動するか
+ * @param storageStatePath 復元するstorageStateファイルのパス（存在する場合）
  * @returns
  */
-export async function openBrowser(userDataDir: string, headless: boolean = true) {
+export async function openBrowser(
+  userDataDir: string,
+  headless: boolean = true,
+  storageStatePath?: string
+) {
   const browserContext = await chromium.launchPersistentContext(userDataDir, {
     headless,
     // ヘッドレスの場合はChromeの新しいヘッドレスモードを使うためにchromiumの指定が必須
@@ -19,6 +24,7 @@ export async function openBrowser(userDataDir: string, headless: boolean = true)
       // headlessモードで起動した際のクラッシュを回避するため
       "--single-process",
     ],
+    storageState: storageStatePath,
   });
 
   // ランダムに表示されるポップアップスクリプトをブロック
@@ -38,38 +44,27 @@ export async function openBrowser(userDataDir: string, headless: boolean = true)
 }
 
 /**
- * Cookieをファイルにバックアップ
- *
- * @param page PlaywrightのPageオブジェクト
- * @param userDataDir ユーザーデータディレクトリのパス
- * @throws ファイル書き込みエラー時
- */
-export async function backupCookies(page: Page, userDataDir: string): Promise<void> {
-  const cookiesFilePath = path.join(userDataDir, "cookies.json");
-  const cookies = await page.context().cookies();
-  fs.writeFileSync(cookiesFilePath, JSON.stringify(cookies, null, 2));
-}
-
-/**
- * Cookieをファイルから復元
+ * storageState（Cookie・localStorage・sessionStorage）をファイルに保存
  *
  * @param browserContext PlaywrightのBrowserContextオブジェクト
  * @param userDataDir ユーザーデータディレクトリのパス
- * @returns 復元に成功したかどうか（ファイルが存在しない場合はfalseを返す）
- * @throws ファイル読み込みエラーやJSON解析エラー時
+ * @throws ファイル書き込みエラー時
  */
-export async function restoreCookies(
+export async function saveStorageState(
   browserContext: BrowserContext,
   userDataDir: string
-): Promise<boolean> {
-  const cookiesFilePath = path.join(userDataDir, "cookies.json");
+): Promise<void> {
+  const stateFilePath = path.join(userDataDir, "storage-state.json");
+  await browserContext.storageState({ path: stateFilePath });
+}
 
-  if (!fs.existsSync(cookiesFilePath)) {
-    return false;
-  }
-
-  const cookiesData = fs.readFileSync(cookiesFilePath, "utf-8");
-  const cookies = JSON.parse(cookiesData);
-  await browserContext.addCookies(cookies);
-  return true;
+/**
+ * storageStateファイルのパスを返す（ファイルが存在する場合のみ）
+ *
+ * @param userDataDir ユーザーデータディレクトリのパス
+ * @returns ファイルが存在すればパス、なければ undefined
+ */
+export function getStorageStatePath(userDataDir: string): string | undefined {
+  const stateFilePath = path.join(userDataDir, "storage-state.json");
+  return fs.existsSync(stateFilePath) ? stateFilePath : undefined;
 }

--- a/src/modules/matsui/scraper.ts
+++ b/src/modules/matsui/scraper.ts
@@ -1,6 +1,6 @@
 import type { Page } from "playwright";
 import { logger } from "../logger.js";
-import { backupCookies, openBrowser, restoreCookies } from "./browser.js";
+import { getStorageStatePath, openBrowser, saveStorageState } from "./browser.js";
 import type { AssetScrapingStrategy } from "./strategies/strategy-interface.js";
 
 const { CHROMIUM_USER_DATA_DIR_MATSUI, HEADLESS } = process.env;
@@ -10,6 +10,7 @@ const { CHROMIUM_USER_DATA_DIR_MATSUI, HEADLESS } = process.env;
  */
 export class MatsuiScraper {
   private strategy: AssetScrapingStrategy<unknown> | null = null;
+  private browserContext: import("playwright").BrowserContext | null = null;
   private page: Page | null = null;
 
   /**
@@ -27,16 +28,17 @@ export class MatsuiScraper {
       throw new Error("環境変数 CHROMIUM_USER_DATA_DIR_MATSUI が設定されていません。");
     }
 
+    const storageStatePath = getStorageStatePath(CHROMIUM_USER_DATA_DIR_MATSUI);
     const { browserContext, page } = await openBrowser(
       CHROMIUM_USER_DATA_DIR_MATSUI,
-      HEADLESS === "true"
+      HEADLESS === "true",
+      storageStatePath
     );
 
-    // Cookie復元を試行
-    const cookiesRestored = await restoreCookies(browserContext, CHROMIUM_USER_DATA_DIR_MATSUI);
-    if (cookiesRestored) {
-      logger.info("保存されているCookieを復元しました。");
+    if (storageStatePath) {
+      logger.info("保存されているストレージ状態を復元しました。");
     }
+    this.browserContext = browserContext;
     this.page = page;
   }
 
@@ -90,18 +92,17 @@ export class MatsuiScraper {
    * ブラウザを閉じてCookieを保存する
    */
   async close(): Promise<void> {
-    if (!this.page) {
+    if (!this.browserContext) {
       return;
     }
     try {
-      await backupCookies(this.page, CHROMIUM_USER_DATA_DIR_MATSUI!);
+      await saveStorageState(this.browserContext, CHROMIUM_USER_DATA_DIR_MATSUI!);
     } catch (error) {
-      logger.error(error, "スクレイピング後のCookie保存中にエラーが発生しました。");
+      logger.error(error, "スクレイピング後のストレージ状態の保存中にエラーが発生しました。");
     }
-    const browserContext = this.page.context();
     try {
       logger.info("ブラウザコンテキストを閉じています。");
-      await browserContext.close();
+      await this.browserContext.close();
       logger.info("ブラウザコンテキストを閉じました。");
     } catch (error) {
       logger.error(error, "ブラウザコンテキストのクローズ中にエラーが発生しました。");

--- a/src/modules/matsui/scraper.ts
+++ b/src/modules/matsui/scraper.ts
@@ -1,4 +1,4 @@
-import type { Page } from "playwright";
+import type { BrowserContext, Page } from "playwright";
 import { logger } from "../logger.js";
 import { getStorageStatePath, openBrowser, saveStorageState } from "./browser.js";
 import type { AssetScrapingStrategy } from "./strategies/strategy-interface.js";
@@ -10,7 +10,7 @@ const { CHROMIUM_USER_DATA_DIR_MATSUI, HEADLESS } = process.env;
  */
 export class MatsuiScraper {
   private strategy: AssetScrapingStrategy<unknown> | null = null;
-  private browserContext: import("playwright").BrowserContext | null = null;
+  private browserContext: BrowserContext | null = null;
   private page: Page | null = null;
 
   /**

--- a/src/modules/matsui/strategies/fund-strategy.ts
+++ b/src/modules/matsui/strategies/fund-strategy.ts
@@ -4,7 +4,7 @@ import type { Position } from "../../../types/matsui.js";
 import { logger } from "../../logger.js";
 import { parseNumber } from "../../utils.js";
 import { getAuthenticationCode } from "../auth.js";
-import { backupCookies } from "../browser.js";
+import { saveStorageState } from "../browser.js";
 import { MatsuiPage } from "../page.js";
 import type { AssetScrapingStrategy } from "./strategy-interface.js";
 
@@ -70,8 +70,8 @@ export class FundStrategy implements AssetScrapingStrategy<Position> {
     ]);
     logger.info("認証ボタンをクリックしました。");
 
-    // ログイン成功後にCookieを保存
-    await backupCookies(page, CHROMIUM_USER_DATA_DIR_MATSUI!);
+    // ログイン成功後にストレージ状態を保存
+    await saveStorageState(page.context(), CHROMIUM_USER_DATA_DIR_MATSUI!);
   }
 
   async prepareTargetPage(page: Page): Promise<Page> {

--- a/src/modules/matsui/strategies/usstock-strategy.ts
+++ b/src/modules/matsui/strategies/usstock-strategy.ts
@@ -3,7 +3,7 @@ import type { UsStockAsset } from "../../../types/matsui.js";
 import { logger } from "../../logger.js";
 import { parseNumber } from "../../utils.js";
 import { getAuthenticationCode } from "../auth.js";
-import { backupCookies } from "../browser.js";
+import { saveStorageState } from "../browser.js";
 import { MatsuiPage } from "../page.js";
 import type { AssetScrapingStrategy } from "./strategy-interface.js";
 
@@ -64,8 +64,8 @@ export class UsStockStrategy implements AssetScrapingStrategy<UsStockAsset> {
     ]);
     logger.info("認証ボタンをクリックしました。");
 
-    // ログイン成功後にCookieを保存
-    await backupCookies(page, CHROMIUM_USER_DATA_DIR_MATSUI!);
+    // ログイン成功後にストレージ状態を保存
+    await saveStorageState(page.context(), CHROMIUM_USER_DATA_DIR_MATSUI!);
   }
 
   async prepareTargetPage(page: Page): Promise<Page> {


### PR DESCRIPTION
## 概要
ブラウザセッション永続化の仕組みを、手動クッキー管理からPlaywright組み込みの `storageState` APIを活用した方式に移行しました。セッション保存時はPlaywrightの `storageState()` メソッドを使用し、復元時は `launchPersistentContext` が `storageState` オプションをサポートしていないため、コンテキスト作成後に `addCookies()` でCookieを復元する方式を採用しています。

## 主な変更点
- **`openBrowser()` 関数の更新**: オプションの `storageStatePath` パラメータを追加し、コンテキスト作成後に `addCookies()` でCookieを復元するよう実装（`launchPersistentContext` は `storageState` オプション非対応のため）
- **`backupCookies()` を `saveStorageState()` に置き換え**: クッキーを手動で抽出・保存する方式から、Playwrightの `storageState()` メソッドを使用してすべてのストレージタイプをキャプチャする方式に変更
- **`restoreCookies()` を `getStorageStatePath()` に置き換え**: ストレージ状態ファイルの存在確認とパス返却を行うユーティリティ関数にシンプル化
- **`MatsuiScraper` クラスの更新**:
  - 適切なクリーンアップのために `browserContext` プロパティを追加
  - `getStorageStatePath()` を使用し、その結果を `openBrowser()` に渡すよう初期化処理を修正
  - `close()` メソッドを `page` の代わりに `browserContext` 経由でストレージ状態を保存するよう更新
- **ストラテジークラスの更新**: `FundStrategy` と `UsStockStrategy` で `page` の代わりに `page.context()` を渡して `saveStorageState()` を呼び出すよう修正
- **未使用インポートの削除**: エクスポート関数で不要になった `Page` 型を browser.ts のインポートから削除

## 実装の詳細
- ストレージ状態は `cookies.json` の代わりに `storage-state.json` に保存されるようになりました
- セッション復元時はストレージ状態ファイルからCookieを読み取り、`addCookies()` で追加します
- クッキーだけでなく完全なセッション状態を保持するため、より堅牢なアプローチです
- `getStorageStatePath()` 内でファイル存在確認を同期的に行い、復元が必要かどうかを判定します
- `storage-state.json` の読み込み失敗時（JSON破損など）は警告ログを出力してCookieなしで続行します
- `launchPersistentContext` の制約により復元対象はCookieのみですが、localStorage・sessionStorageはユーザーデータディレクトリのプロファイルに保持されるため実用上の問題はありません

## 移行について
- 既存環境に `cookies.json` が存在する場合、`storage-state.json` が生成されるまでは初回のみ再認証が必要になります