### PR TITLE
fix: ログインページのボタン特定エラーとnetworkidleタイムアウトを修正

### DIFF
--- a/src/modules/matsui/strategies/fund-strategy.ts
+++ b/src/modules/matsui/strategies/fund-strategy.ts
@@ -47,7 +47,7 @@ export class FundStrategy implements AssetScrapingStrategy<Position> {
     logger.info("ログイン情報を入力しました。");
 
     // ログインボタンをクリック
-    const loginButton = page.locator("button").filter({ hasText: "ログイン" });
+    const loginButton = page.locator('#login-id-area button[type="submit"]');
     await Promise.all([page.waitForURL("**", { timeout: 10000 }), loginButton.click()]);
     logger.info("ログインボタンをクリックしました。");
 

--- a/src/modules/matsui/strategies/fund-strategy.ts
+++ b/src/modules/matsui/strategies/fund-strategy.ts
@@ -91,9 +91,6 @@ export class FundStrategy implements AssetScrapingStrategy<Position> {
     await activateButton.click();
     logger.info("投資信託サイトの起動ボタンをクリックしました。");
 
-    // 画面遷移の待機
-    await page.waitForLoadState("networkidle");
-
     // iframe内の「起動する」画像をクリックして新しいタブが開くのを待つ
     const iframe = page.frameLocator("#net-stock-contents");
     logger.info("iframeの読み込みを待機中...");

--- a/src/modules/matsui/strategies/fund-strategy.ts
+++ b/src/modules/matsui/strategies/fund-strategy.ts
@@ -39,7 +39,7 @@ export class FundStrategy implements AssetScrapingStrategy<Position> {
 
     // ログインページに移動
     await page.goto(MatsuiPage.tradeLogin);
-    await page.waitForLoadState("networkidle");
+    await page.locator("#login-id").waitFor({ state: "visible" });
 
     // ログイン情報を入力
     await page.fill("#login-id", MATSUI_LOGIN_ID);


### PR DESCRIPTION
## 概要

松井証券サイトのUI変更に伴い発生した2種類のエラーを修正します。

## 修正内容

### 1. ログインボタンのロケーターが複数要素にマッチするエラー

パスキー認証機能の追加により「ログイン」を含むボタンが4つになり、strict mode violation が発生していた。

```diff
- const loginButton = page.locator("button").filter({ hasText: "ログイン" });
+ const loginButton = page.locator('#login-id-area button[type="submit"]');
```

`#login-id-area` 内の `type="submit"` ボタンを直接指定することで、意図したボタンのみを対象とするよう変更。

### 2. `waitForLoadState("networkidle")` のタイムアウト

KARTE・rtoaster・Google Tag Manager などの3rdパーティスクリプトが動的にDOM要素を注入し続けるため、networkidle に到達できずタイムアウトが発生していた。

**ログインページ:**
```diff
- await page.waitForLoadState("networkidle");
+ await page.locator("#login-id").waitFor({ state: "visible" });
```
ログインフォームの入力欄が表示された時点で処理を継続するよう変更。

**投資信託ページ:**
```diff
- // 画面遷移の待機
- await page.waitForLoadState("networkidle");
```
直後の `launchButton.waitFor({ state: "visible" })` がiframeコンテンツの表示を担保するため、冗長なnetworkidle待機を削除。