### PR TITLE
refactor: ログイン方式をスクレイピング戦略から分離する

### DIFF
--- a/src/commands/sync-matsui-zaim.ts
+++ b/src/commands/sync-matsui-zaim.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { loadConfig } from "../modules/config.js";
 import { configureLogger, logger, MatsuiScraper, Zaim } from "../modules/index.js";
+import { PasswordLoginMethod } from "../modules/matsui/login-methods/password-login.js";
 import { MatsuiZaimSyncService } from "../modules/sync/sync-service.js";
 import { TotalAmountRepository } from "../modules/sync/total-amount-repository.js";
 
@@ -27,9 +28,10 @@ program
 
       // 依存性の注入
       const scraper = new MatsuiScraper();
+      const loginMethod = new PasswordLoginMethod();
       const totalAmountRepo = new TotalAmountRepository(ZAIM_TOTAL_AMOUNT_FILE);
       const zaimClient = new Zaim();
-      const syncService = new MatsuiZaimSyncService(scraper, totalAmountRepo, zaimClient);
+      const syncService = new MatsuiZaimSyncService(scraper, loginMethod, totalAmountRepo, zaimClient);
 
       // 同期実行
       await syncService.sync(config, { dryRun: options.dryRun });

--- a/src/modules/matsui/login-methods/login-method.ts
+++ b/src/modules/matsui/login-methods/login-method.ts
@@ -1,0 +1,19 @@
+import type { Page } from "playwright";
+
+/**
+ * 松井証券へのログイン方式のインターフェース
+ */
+export interface MatsuiLoginMethod {
+  /**
+   * セッションの有効性を確認する
+   * @param page PlaywrightのPageオブジェクト
+   * @returns セッションが有効かどうか
+   */
+  isSessionValid(page: Page): Promise<boolean>;
+
+  /**
+   * ログイン処理を実行する
+   * @param page PlaywrightのPageオブジェクト
+   */
+  login(page: Page): Promise<void>;
+}

--- a/src/modules/matsui/login-methods/password-login.ts
+++ b/src/modules/matsui/login-methods/password-login.ts
@@ -1,0 +1,71 @@
+import type { Page } from "playwright";
+import { logger } from "../../logger.js";
+import { getAuthenticationCode } from "../auth.js";
+import { saveStorageState } from "../browser.js";
+import { MatsuiPage } from "../page.js";
+import type { MatsuiLoginMethod } from "./login-method.js";
+
+const { CHROMIUM_USER_DATA_DIR_MATSUI, MATSUI_LOGIN_ID, MATSUI_PASSWORD } = process.env;
+
+/**
+ * パスワード認証によるログイン実装
+ */
+export class PasswordLoginMethod implements MatsuiLoginMethod {
+  async isSessionValid(page: Page): Promise<boolean> {
+    try {
+      await page.goto(MatsuiPage.tradeMemberHome, { timeout: 10000 });
+      const url = page.url();
+
+      if (url.includes(MatsuiPage.tradeMente)) {
+        throw new Error("メンテナンス中のため同期を実行できません。");
+      }
+
+      return !url.includes("/login");
+    } catch (error) {
+      logger.error(error, "セッション有効性チェック中にエラーが発生しました。");
+      return false;
+    }
+  }
+
+  async login(page: Page): Promise<void> {
+    if (!MATSUI_LOGIN_ID || !MATSUI_PASSWORD) {
+      throw new Error("環境変数 MATSUI_LOGIN_ID または MATSUI_PASSWORD が設定されていません。");
+    }
+
+    // ログインページに移動
+    await page.goto(MatsuiPage.tradeLogin);
+    await page.locator("#login-id").waitFor({ state: "visible" });
+
+    // ログイン情報を入力
+    await page.fill("#login-id", MATSUI_LOGIN_ID);
+    await page.fill("#login-password", MATSUI_PASSWORD);
+    logger.info("ログイン情報を入力しました。");
+
+    // ログインボタンをクリック
+    const loginButton = page.locator('#login-id-area button[type="submit"]');
+    await Promise.all([page.waitForURL("**", { timeout: 10000 }), loginButton.click()]);
+    logger.info("ログインボタンをクリックしました。");
+
+    // メンテナンスページにリダイレクトされた場合
+    const currentUrl = page.url();
+    if (currentUrl.includes(MatsuiPage.tradeMente)) {
+      throw new Error("メンテナンス中のため同期を実行できません。");
+    }
+
+    // 認証コードを入力
+    const { authenticationCode } = await getAuthenticationCode();
+    await page.fill('input[name="auth-number"]', authenticationCode);
+    logger.info("認証コードを入力しました。");
+
+    // 認証ボタンをクリック
+    const authButton = page.locator("#auth-btn");
+    await Promise.all([
+      page.waitForURL(MatsuiPage.tradeMemberHome, { timeout: 10000 }),
+      authButton.click(),
+    ]);
+    logger.info("認証ボタンをクリックしました。");
+
+    // ログイン成功後にストレージ状態を保存
+    await saveStorageState(page.context(), CHROMIUM_USER_DATA_DIR_MATSUI!);
+  }
+}

--- a/src/modules/matsui/login-methods/password-login.ts
+++ b/src/modules/matsui/login-methods/password-login.ts
@@ -22,6 +22,9 @@ export class PasswordLoginMethod implements MatsuiLoginMethod {
 
       return !url.includes("/login");
     } catch (error) {
+      if (error instanceof Error && error.message.includes("メンテナンス")) {
+        throw error;
+      }
       logger.error(error, "セッション有効性チェック中にエラーが発生しました。");
       return false;
     }

--- a/src/modules/matsui/scraper.ts
+++ b/src/modules/matsui/scraper.ts
@@ -1,6 +1,7 @@
 import type { BrowserContext, Page } from "playwright";
 import { logger } from "../logger.js";
 import { getStorageStatePath, openBrowser, saveStorageState } from "./browser.js";
+import type { MatsuiLoginMethod } from "./login-methods/login-method.js";
 import type { AssetScrapingStrategy } from "./strategies/strategy-interface.js";
 
 const { CHROMIUM_USER_DATA_DIR_MATSUI, HEADLESS } = process.env;
@@ -9,6 +10,7 @@ const { CHROMIUM_USER_DATA_DIR_MATSUI, HEADLESS } = process.env;
  * 松井証券のスクレイピングを管理するクラス
  */
 export class MatsuiScraper {
+  private loginMethod: MatsuiLoginMethod | null = null;
   private strategy: AssetScrapingStrategy<unknown> | null = null;
   private browserContext: BrowserContext | null = null;
   private page: Page | null = null;
@@ -43,6 +45,14 @@ export class MatsuiScraper {
   }
 
   /**
+   * ログイン方式を設定する
+   * @param loginMethod 設定するログイン方式
+   */
+  setLoginMethod(loginMethod: MatsuiLoginMethod): void {
+    this.loginMethod = loginMethod;
+  }
+
+  /**
    * スクレイピング戦略を設定する
    * @param strategy 設定する戦略
    */
@@ -54,16 +64,16 @@ export class MatsuiScraper {
    * 認証処理を実行する（セッション確認→必要に応じてログイン）
    */
   async authenticate(): Promise<void> {
-    if (!this.strategy || !this.page) {
-      throw new Error("スクレイピング戦略またはページが初期化されていません。");
+    if (!this.loginMethod || !this.page) {
+      throw new Error("ログイン方式またはページが初期化されていません。");
     }
 
     logger.info("セッションの有効性をチェックします。");
-    const sessionValid = await this.strategy.isSessionValid(this.page);
+    const sessionValid = await this.loginMethod.isSessionValid(this.page);
 
     if (!sessionValid) {
       logger.info("セッションが無効なため、ログインを実行します。");
-      await this.strategy.login(this.page);
+      await this.loginMethod.login(this.page);
       logger.info("ログインが完了しました。");
     } else {
       logger.info("既存のセッションを使用します。");

--- a/src/modules/matsui/strategies/fund-strategy.ts
+++ b/src/modules/matsui/strategies/fund-strategy.ts
@@ -3,77 +3,13 @@ import playwright from "playwright";
 import type { Position } from "../../../types/matsui.js";
 import { logger } from "../../logger.js";
 import { parseNumber } from "../../utils.js";
-import { getAuthenticationCode } from "../auth.js";
-import { saveStorageState } from "../browser.js";
 import { MatsuiPage } from "../page.js";
 import type { AssetScrapingStrategy } from "./strategy-interface.js";
-
-const { CHROMIUM_USER_DATA_DIR_MATSUI, MATSUI_LOGIN_ID, MATSUI_PASSWORD } = process.env;
 
 /**
  * 投資信託の資産データをスクレイピングする戦略
  */
 export class FundStrategy implements AssetScrapingStrategy<Position> {
-  async isSessionValid(page: Page): Promise<boolean> {
-    try {
-      await page.goto(MatsuiPage.tradeMemberHome, { timeout: 10000 });
-      const url = page.url();
-
-      // メンテナンスページにリダイレクトされた場合
-      if (url.includes(MatsuiPage.tradeMente)) {
-        throw new Error("メンテナンス中のため同期を実行できません。");
-      }
-
-      // ログインページにリダイレクトされていないかチェック
-      return !url.includes("/login");
-    } catch (error) {
-      logger.error(error, "セッション有効性チェック中にエラーが発生しました。");
-      return false;
-    }
-  }
-
-  async login(page: Page): Promise<void> {
-    if (!MATSUI_LOGIN_ID || !MATSUI_PASSWORD) {
-      throw new Error("環境変数 MATSUI_LOGIN_ID または MATSUI_PASSWORD が設定されていません。");
-    }
-
-    // ログインページに移動
-    await page.goto(MatsuiPage.tradeLogin);
-    await page.locator("#login-id").waitFor({ state: "visible" });
-
-    // ログイン情報を入力
-    await page.fill("#login-id", MATSUI_LOGIN_ID);
-    await page.fill("#login-password", MATSUI_PASSWORD);
-    logger.info("ログイン情報を入力しました。");
-
-    // ログインボタンをクリック
-    const loginButton = page.locator('#login-id-area button[type="submit"]');
-    await Promise.all([page.waitForURL("**", { timeout: 10000 }), loginButton.click()]);
-    logger.info("ログインボタンをクリックしました。");
-
-    // メンテナンスページにリダイレクトされた場合
-    const currentUrl = page.url();
-    if (currentUrl.includes(MatsuiPage.tradeMente)) {
-      throw new Error("メンテナンス中のため同期を実行できません。");
-    }
-
-    // 認証コードを入力
-    const { authenticationCode } = await getAuthenticationCode();
-    await page.fill('input[name="auth-number"]', authenticationCode);
-    logger.info("認証コードを入力しました。");
-
-    // 認証ボタンをクリック
-    const authButton = page.locator("#auth-btn");
-    await Promise.all([
-      page.waitForURL(MatsuiPage.tradeMemberHome, { timeout: 10000 }),
-      authButton.click(),
-    ]);
-    logger.info("認証ボタンをクリックしました。");
-
-    // ログイン成功後にストレージ状態を保存
-    await saveStorageState(page.context(), CHROMIUM_USER_DATA_DIR_MATSUI!);
-  }
-
   async prepareTargetPage(page: Page): Promise<Page> {
     // 投資信託メニューをクリック
     const mutualFundMenuLink = page

--- a/src/modules/matsui/strategies/strategy-interface.ts
+++ b/src/modules/matsui/strategies/strategy-interface.ts
@@ -5,19 +5,6 @@ import type { Page } from "playwright";
  */
 export interface AssetScrapingStrategy<T> {
   /**
-   * セッションの有効性を確認する
-   * @param page PlaywrightのPageオブジェクト
-   * @returns セッションが有効かどうか
-   */
-  isSessionValid(page: Page): Promise<boolean>;
-
-  /**
-   * ログイン処理を実行する
-   * @param page PlaywrightのPageオブジェクト
-   */
-  login(page: Page): Promise<void>;
-
-  /**
    * スクレイピング対象のページを準備する（オプショナル）
    * @param page PlaywrightのPageオブジェクト
    * @returns スクレイピングに使用するPageオブジェクト

--- a/src/modules/matsui/strategies/usstock-strategy.ts
+++ b/src/modules/matsui/strategies/usstock-strategy.ts
@@ -2,72 +2,13 @@ import type { Page } from "playwright";
 import type { UsStockAsset } from "../../../types/matsui.js";
 import { logger } from "../../logger.js";
 import { parseNumber } from "../../utils.js";
-import { getAuthenticationCode } from "../auth.js";
-import { saveStorageState } from "../browser.js";
 import { MatsuiPage } from "../page.js";
 import type { AssetScrapingStrategy } from "./strategy-interface.js";
-
-const { CHROMIUM_USER_DATA_DIR_MATSUI, MATSUI_LOGIN_ID, MATSUI_PASSWORD } = process.env;
 
 /**
  * 米国株の資産データをスクレイピングする戦略
  */
 export class UsStockStrategy implements AssetScrapingStrategy<UsStockAsset> {
-  async isSessionValid(page: Page): Promise<boolean> {
-    try {
-      await page.goto(MatsuiPage.tradeMemberHome, { timeout: 10000 });
-      // ログインページにリダイレクトされていないかチェック
-      const url = page.url();
-      // TODO: メンテナンスページにリダイレクトされた場合の処理を実装
-      return !url.includes("/login");
-    } catch (error) {
-      logger.error(error, "セッション有効性チェック中にエラーが発生しました。");
-      return false;
-    }
-  }
-
-  async login(page: Page): Promise<void> {
-    if (!MATSUI_LOGIN_ID || !MATSUI_PASSWORD) {
-      throw new Error("環境変数 MATSUI_LOGIN_ID または MATSUI_PASSWORD が設定されていません。");
-    }
-
-    // ログインページに移動
-    await page.goto(MatsuiPage.tradeLogin);
-    await page.waitForLoadState("networkidle");
-
-    // ログイン情報を入力
-    await page.fill("#login-id", MATSUI_LOGIN_ID);
-    await page.fill("#login-password", MATSUI_PASSWORD);
-    logger.info("ログイン情報を入力しました。");
-
-    // ログインボタンをクリック
-    const loginButton = page.locator("button").filter({ hasText: "ログイン" });
-    await Promise.all([page.waitForURL("**", { timeout: 10000 }), loginButton.click()]);
-    logger.info("ログインボタンをクリックしました。");
-
-    // メンテナンスページにリダイレクトされた場合
-    const currentUrl = page.url();
-    if (currentUrl.includes(MatsuiPage.tradeMente)) {
-      throw new Error("メンテナンス中のため同期を実行できません。");
-    }
-
-    // 認証コードを入力
-    const { authenticationCode } = await getAuthenticationCode();
-    await page.fill('input[name="auth-number"]', authenticationCode);
-    logger.info("認証コードを入力しました。");
-
-    // 認証ボタンをクリック
-    const authButton = page.locator("#auth-btn");
-    await Promise.all([
-      page.waitForURL(MatsuiPage.tradeMemberHome, { timeout: 10000 }),
-      authButton.click(),
-    ]);
-    logger.info("認証ボタンをクリックしました。");
-
-    // ログイン成功後にストレージ状態を保存
-    await saveStorageState(page.context(), CHROMIUM_USER_DATA_DIR_MATSUI!);
-  }
-
   async prepareTargetPage(page: Page): Promise<Page> {
     // ヘッダの「米国株」メニューから辿るとブラウザの実行環境起因でエラー画面になってしまうため、資産状況ページから辿る。
 

--- a/src/modules/sync/sync-service.ts
+++ b/src/modules/sync/sync-service.ts
@@ -4,7 +4,7 @@ import path from "path";
 import type { Page } from "playwright";
 import type { AccountConfig, AppConfig, MatsuiConfig, StrategyType } from "../config.js";
 import { logger } from "../logger.js";
-import { PasswordLoginMethod } from "../matsui/login-methods/password-login.js";
+import type { MatsuiLoginMethod } from "../matsui/login-methods/login-method.js";
 import type { MatsuiScraper } from "../matsui/scraper.js";
 import { StrategyFactory } from "../matsui/strategies/index.js";
 import type { Zaim } from "../zaim/client.js";
@@ -25,6 +25,7 @@ export interface LastTotalAmount {
 export class MatsuiZaimSyncService {
   constructor(
     private scraper: MatsuiScraper,
+    private loginMethod: MatsuiLoginMethod,
     private totalAmountRepo: TotalAmountRepository,
     private zaimClient: Zaim
   ) {}
@@ -51,8 +52,7 @@ export class MatsuiZaimSyncService {
       logger.info("資産評価額を取得します。");
       const scrapedDataMap = new Map<StrategyType, any>();
 
-      const loginMethod = new PasswordLoginMethod();
-      this.scraper.setLoginMethod(loginMethod);
+      this.scraper.setLoginMethod(this.loginMethod);
 
       for (const [strategyType, _] of strategyGroups) {
         try {

--- a/src/modules/sync/sync-service.ts
+++ b/src/modules/sync/sync-service.ts
@@ -4,6 +4,7 @@ import path from "path";
 import type { Page } from "playwright";
 import type { AccountConfig, AppConfig, MatsuiConfig, StrategyType } from "../config.js";
 import { logger } from "../logger.js";
+import { PasswordLoginMethod } from "../matsui/login-methods/password-login.js";
 import type { MatsuiScraper } from "../matsui/scraper.js";
 import { StrategyFactory } from "../matsui/strategies/index.js";
 import type { Zaim } from "../zaim/client.js";
@@ -49,6 +50,9 @@ export class MatsuiZaimSyncService {
       // 各戦略を実行してデータ取得
       logger.info("資産評価額を取得します。");
       const scrapedDataMap = new Map<StrategyType, any>();
+
+      const loginMethod = new PasswordLoginMethod();
+      this.scraper.setLoginMethod(loginMethod);
 
       for (const [strategyType, _] of strategyGroups) {
         try {


### PR DESCRIPTION
## Summary

- `AssetScrapingStrategy` に混在していたログイン責務（`isSessionValid` / `login`）を `MatsuiLoginMethod` インターフェースとして切り出した
- `FundStrategy` / `UsStockStrategy` の重複していたログイン実装を `PasswordLoginMethod` に統合
- `MatsuiZaimSyncService` のコンストラクタで `MatsuiLoginMethod` を受け取るよう変更し、呼び出し元でどのログイン方式を使うか決める設計に変更
- `isSessionValid()` 内でメンテナンスエラーが握り潰されていたバグを修正

## Test plan

- [ ] `npx tsc --noEmit` が通ること
- [ ] `npx vitest run` が全パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)