### PR TITLE
refactor: ページリセットを prepareTargetPage に移し必須化する

### DIFF
--- a/src/modules/matsui/login-methods/login-method.ts
+++ b/src/modules/matsui/login-methods/login-method.ts
@@ -16,10 +16,4 @@ export interface MatsuiLoginMethod {
    * @param page PlaywrightのPageオブジェクト
    */
   login(page: Page): Promise<void>;
-
-  /**
-   * スクレイピングの開始地点となるページに遷移する
-   * @param page PlaywrightのPageオブジェクト
-   */
-  navigateToHome(page: Page): Promise<void>;
 }

--- a/src/modules/matsui/login-methods/login-method.ts
+++ b/src/modules/matsui/login-methods/login-method.ts
@@ -16,4 +16,10 @@ export interface MatsuiLoginMethod {
    * @param page PlaywrightのPageオブジェクト
    */
   login(page: Page): Promise<void>;
+
+  /**
+   * スクレイピングの開始地点となるページに遷移する
+   * @param page PlaywrightのPageオブジェクト
+   */
+  navigateToHome(page: Page): Promise<void>;
 }

--- a/src/modules/matsui/login-methods/password-login.ts
+++ b/src/modules/matsui/login-methods/password-login.ts
@@ -13,20 +13,21 @@ const { CHROMIUM_USER_DATA_DIR_MATSUI, MATSUI_LOGIN_ID, MATSUI_PASSWORD } = proc
 export class PasswordLoginMethod implements MatsuiLoginMethod {
   async isSessionValid(page: Page): Promise<boolean> {
     try {
-      await page.goto(MatsuiPage.tradeMemberHome, { timeout: 10000 });
-      const url = page.url();
-
-      if (url.includes(MatsuiPage.tradeMente)) {
-        throw new Error("メンテナンス中のため同期を実行できません。");
-      }
-
-      return !url.includes("/login");
+      await this.navigateToHome(page);
+      return !page.url().includes("/login");
     } catch (error) {
       if (error instanceof Error && error.message.includes("メンテナンス")) {
         throw error;
       }
       logger.error(error, "セッション有効性チェック中にエラーが発生しました。");
       return false;
+    }
+  }
+
+  async navigateToHome(page: Page): Promise<void> {
+    await page.goto(MatsuiPage.tradeMemberHome, { timeout: 10000 });
+    if (page.url().includes(MatsuiPage.tradeMente)) {
+      throw new Error("メンテナンス中のため同期を実行できません。");
     }
   }
 

--- a/src/modules/matsui/login-methods/password-login.ts
+++ b/src/modules/matsui/login-methods/password-login.ts
@@ -24,7 +24,7 @@ export class PasswordLoginMethod implements MatsuiLoginMethod {
     }
   }
 
-  async navigateToHome(page: Page): Promise<void> {
+  private async navigateToHome(page: Page): Promise<void> {
     await page.goto(MatsuiPage.tradeMemberHome, { timeout: 10000 });
     if (page.url().includes(MatsuiPage.tradeMente)) {
       throw new Error("メンテナンス中のため同期を実行できません。");

--- a/src/modules/matsui/scraper.ts
+++ b/src/modules/matsui/scraper.ts
@@ -61,6 +61,16 @@ export class MatsuiScraper {
   }
 
   /**
+   * スクレイピングの開始地点となるページに遷移する
+   */
+  async navigateToHome(): Promise<void> {
+    if (!this.loginMethod || !this.page) {
+      throw new Error("ログイン方式またはページが初期化されていません。");
+    }
+    await this.loginMethod.navigateToHome(this.page);
+  }
+
+  /**
    * 認証処理を実行する（セッション確認→必要に応じてログイン）
    */
   async authenticate(): Promise<void> {

--- a/src/modules/matsui/scraper.ts
+++ b/src/modules/matsui/scraper.ts
@@ -61,16 +61,6 @@ export class MatsuiScraper {
   }
 
   /**
-   * スクレイピングの開始地点となるページに遷移する
-   */
-  async navigateToHome(): Promise<void> {
-    if (!this.loginMethod || !this.page) {
-      throw new Error("ログイン方式またはページが初期化されていません。");
-    }
-    await this.loginMethod.navigateToHome(this.page);
-  }
-
-  /**
    * 認証処理を実行する（セッション確認→必要に応じてログイン）
    */
   async authenticate(): Promise<void> {
@@ -99,12 +89,7 @@ export class MatsuiScraper {
       throw new Error("スクレイピング戦略またはページが初期化されていません。");
     }
 
-    // スクレイピング対象のページを準備
-    let targetPage = this.page;
-    if (this.strategy.prepareTargetPage) {
-      targetPage = await this.strategy.prepareTargetPage(this.page);
-    }
-
+    const targetPage = await this.strategy.prepareTargetPage(this.page);
     return (await this.strategy.scrapeAssets(targetPage)) as T;
   }
 

--- a/src/modules/matsui/strategies/fund-strategy.ts
+++ b/src/modules/matsui/strategies/fund-strategy.ts
@@ -11,6 +11,8 @@ import type { AssetScrapingStrategy } from "./strategy-interface.js";
  */
 export class FundStrategy implements AssetScrapingStrategy<Position> {
   async prepareTargetPage(page: Page): Promise<Page> {
+    await page.goto(MatsuiPage.tradeMemberHome);
+
     // 投資信託メニューをクリック
     const mutualFundMenuLink = page
       .locator('#common-header [data-page="mutual-fund-top"]')

--- a/src/modules/matsui/strategies/strategy-interface.ts
+++ b/src/modules/matsui/strategies/strategy-interface.ts
@@ -9,7 +9,7 @@ export interface AssetScrapingStrategy<T> {
    * @param page PlaywrightのPageオブジェクト
    * @returns スクレイピングに使用するPageオブジェクト
    */
-  prepareTargetPage?(page: Page): Promise<Page>;
+  prepareTargetPage(page: Page): Promise<Page>;
 
   /**
    * 資産データをスクレイピングする

--- a/src/modules/matsui/strategies/usstock-strategy.ts
+++ b/src/modules/matsui/strategies/usstock-strategy.ts
@@ -10,6 +10,8 @@ import type { AssetScrapingStrategy } from "./strategy-interface.js";
  */
 export class UsStockStrategy implements AssetScrapingStrategy<UsStockAsset> {
   async prepareTargetPage(page: Page): Promise<Page> {
+    await page.goto(MatsuiPage.tradeMemberHome);
+
     // ヘッダの「米国株」メニューから辿るとブラウザの実行環境起因でエラー画面になってしまうため、資産状況ページから辿る。
 
     // 資産状況ページに遷移

--- a/src/modules/sync/sync-service.ts
+++ b/src/modules/sync/sync-service.ts
@@ -58,7 +58,6 @@ export class MatsuiZaimSyncService {
       for (const [strategyType, _] of strategyGroups) {
         try {
           logger.info(`戦略 ${strategyType} の処理を開始します。`);
-          await this.scraper.navigateToHome();
           const strategy = StrategyFactory.create(strategyType);
           this.scraper.setStrategy(strategy);
           logger.info(`戦略 ${strategyType} のスクレイピングを開始します。`);

--- a/src/modules/sync/sync-service.ts
+++ b/src/modules/sync/sync-service.ts
@@ -53,15 +53,14 @@ export class MatsuiZaimSyncService {
       const scrapedDataMap = new Map<StrategyType, any>();
 
       this.scraper.setLoginMethod(this.loginMethod);
+      await this.scraper.authenticate();
 
       for (const [strategyType, _] of strategyGroups) {
         try {
           logger.info(`戦略 ${strategyType} の処理を開始します。`);
+          await this.scraper.navigateToHome();
           const strategy = StrategyFactory.create(strategyType);
           this.scraper.setStrategy(strategy);
-          logger.info(`戦略 ${strategyType} の認証を開始します。`);
-          await this.scraper.authenticate();
-          logger.info(`戦略 ${strategyType} の認証が完了しました。`);
           logger.info(`戦略 ${strategyType} のスクレイピングを開始します。`);
           const data = await this.scraper.scrape();
           logger.info(`戦略 ${strategyType} のスクレイピングが完了しました。`);


### PR DESCRIPTION
## Summary

- `isSessionValid()` が副作用として担っていた `tradeMemberHome` へのナビゲーションを `prepareTargetPage()` 内に移動し、責務を明示的に分離した
- `prepareTargetPage` をインターフェース上でオプショナルから必須に変更
- `authenticate()` をループ外で1回だけ呼ぶよう変更し、ログインは最大1回になった
- `MatsuiScraper.scrape()` の `prepareTargetPage` 存在チェックが不要になり削除

## Test plan

- [x] `npx tsc --noEmit` が通ること
- [x] `npx vitest run` が全パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)