### PR TITLE
ci: ドラフトPRがReady for reviewになった際にCIが実行されない問題を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +19,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## 背景

main以外のブランチに向けてDraftのPRを作成し、その後Base automatically changedが発生した場合、GitHub ActionsはBase変更を`synchronize`イベントとして扱いません。そのため、その後PRをReady for reviewに変更しても、`pull_request`イベントのデフォルトトリガー（`opened`, `synchronize`, `reopened`）に`ready_for_review`が含まれていなかったため、CIが実行されませんでした。

## 変更内容

- `pull_request`イベントの`types`に`ready_for_review`を追加し、ドラフト解除時にCIが確実に実行されるようにした
- ドラフトPRへのpush時にCIを不要に実行しないよう、`if`条件を追加した
  - `push`イベント（mainへの直接push）では常に実行
  - `pull_request`イベントではドラフトでない場合のみ実行