### PR TITLE
refactor: ログインメソッドをサブディレクトリに整理してファクトリを導入

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,6 @@
 			"extensions": [
 				"Anthropic.claude-code",
 				"esbenp.prettier-vscode",
-				"google.gemini-cli-vscode-ide-companion",
 				"MermaidChart.vscode-mermaid-chart",
 				"vitest.explorer"
 			]
@@ -57,9 +56,6 @@
 
 	// Mounts source folder to target folder.
 	"mounts": [
-		// Gemini CLI
-		"source=${localWorkspaceFolder}/.devcontainer/gemini-config,target=/home/node/.gemini,type=bind",
-		"source=${localWorkspaceFolder}/.devcontainer/gemini-config,target=/home/node/.gemini,type=bind",
 		// Claude Code
 		"source=${localWorkspaceFolder}/.devcontainer/claude-config/.claude.json,target=/home/node/.claude.json,type=bind",
 		"source=${localWorkspaceFolder}/.devcontainer/claude-config/.claude,target=/home/node/.claude,type=bind",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Install Gemini CLI globally
-npm install -g @google/gemini-cli
-
 # Install Claude Code globally
 npm install -g @anthropic-ai/claude-code
 

--- a/.gitignore
+++ b/.gitignore
@@ -138,9 +138,6 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
-# Gemini Configuration files
-.devcontainer/gemini-config
-
 # Claude Configuration files
 .devcontainer/claude-config
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,0 @@
-## Gemini Added Memories
-- All future memories and persistent instructions should be recorded in this `GEMINI.md` file.
-    - Because the development environment is a devcontainer.
-- The user will run the `npm start` command manually. I should not run it myself, as it fails due to network issues in my execution environment.
-- Use a 4-space indent for nested lists in this file.

--- a/src/commands/sync-matsui-zaim.ts
+++ b/src/commands/sync-matsui-zaim.ts
@@ -2,8 +2,7 @@
 import { Command } from "commander";
 import { loadConfig } from "../modules/config.js";
 import { configureLogger, logger, MatsuiScraper, Zaim } from "../modules/index.js";
-import { PasskeyLoginMethod } from "../modules/matsui/login-methods/passkey-login.js";
-import { PasswordLoginMethod } from "../modules/matsui/login-methods/password-login.js";
+import { LoginMethodFactory } from "../modules/matsui/login-methods/index.js";
 import { MatsuiZaimSyncService } from "../modules/sync/sync-service.js";
 import { TotalAmountRepository } from "../modules/sync/total-amount-repository.js";
 
@@ -29,8 +28,9 @@ program
 
       // 依存性の注入
       const scraper = new MatsuiScraper();
-      const loginMethod =
-        MATSUI_LOGIN_METHOD === "passkey" ? new PasskeyLoginMethod() : new PasswordLoginMethod();
+      const loginMethod = LoginMethodFactory.create(
+        MATSUI_LOGIN_METHOD === "passkey" ? "passkey" : "password",
+      );
       const totalAmountRepo = new TotalAmountRepository(ZAIM_TOTAL_AMOUNT_FILE);
       const zaimClient = new Zaim();
       const syncService = new MatsuiZaimSyncService(

--- a/src/modules/matsui/login-methods/index.ts
+++ b/src/modules/matsui/login-methods/index.ts
@@ -1,0 +1,16 @@
+import type { MatsuiLoginMethod } from "./login-method.js";
+import { PasskeyLoginMethod } from "./passkey/index.js";
+import { PasswordLoginMethod } from "./password/index.js";
+
+export type LoginMethodName = "password" | "passkey";
+
+export class LoginMethodFactory {
+  static create(methodName: LoginMethodName): MatsuiLoginMethod {
+    switch (methodName) {
+      case "password":
+        return new PasswordLoginMethod();
+      case "passkey":
+        return new PasskeyLoginMethod();
+    }
+  }
+}

--- a/src/modules/matsui/login-methods/index.ts
+++ b/src/modules/matsui/login-methods/index.ts
@@ -2,7 +2,7 @@ import type { MatsuiLoginMethod } from "./login-method.js";
 import { PasskeyLoginMethod } from "./passkey/index.js";
 import { PasswordLoginMethod } from "./password/index.js";
 
-export type LoginMethodName = "password" | "passkey";
+type LoginMethodName = "password" | "passkey";
 
 export class LoginMethodFactory {
   static create(methodName: LoginMethodName): MatsuiLoginMethod {

--- a/src/modules/matsui/login-methods/passkey/index.ts
+++ b/src/modules/matsui/login-methods/passkey/index.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
 import path from "path";
 import type { CDPSession, Page } from "playwright";
-import { logger } from "../../logger.js";
-import { saveStorageState } from "../browser.js";
-import { MatsuiPage } from "../page.js";
-import type { MatsuiLoginMethod } from "./login-method.js";
+import { logger } from "../../../logger.js";
+import { saveStorageState } from "../../browser.js";
+import { MatsuiPage } from "../../page.js";
+import type { MatsuiLoginMethod } from "../login-method.js";
 
 const { CHROMIUM_USER_DATA_DIR_MATSUI } = process.env;
 

--- a/src/modules/matsui/login-methods/password/authentication-code.ts
+++ b/src/modules/matsui/login-methods/password/authentication-code.ts
@@ -2,8 +2,8 @@ import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat.js";
 import type { BrowserContext, Page } from "playwright";
-import { logger } from "../logger.js";
-import { openBrowser } from "./browser.js";
+import { logger } from "../../../logger.js";
+import { openBrowser } from "../../browser.js";
 
 dayjs.extend(customParseFormat);
 

--- a/src/modules/matsui/login-methods/password/index.ts
+++ b/src/modules/matsui/login-methods/password/index.ts
@@ -1,9 +1,9 @@
 import type { Page } from "playwright";
-import { logger } from "../../logger.js";
-import { getAuthenticationCode } from "../auth.js";
-import { saveStorageState } from "../browser.js";
-import { MatsuiPage } from "../page.js";
-import type { MatsuiLoginMethod } from "./login-method.js";
+import { logger } from "../../../logger.js";
+import { getAuthenticationCode } from "./authentication-code.js";
+import { saveStorageState } from "../../browser.js";
+import { MatsuiPage } from "../../page.js";
+import type { MatsuiLoginMethod } from "../login-method.js";
 
 const { CHROMIUM_USER_DATA_DIR_MATSUI, MATSUI_LOGIN_ID, MATSUI_PASSWORD } = process.env;
 

--- a/src/modules/matsui/strategies/index.ts
+++ b/src/modules/matsui/strategies/index.ts
@@ -1,6 +1,6 @@
 import { FundStrategy } from "./fund-strategy.js";
-import { UsStockStrategy } from "./usstock-strategy.js";
 import type { AssetScrapingStrategy } from "./strategy-interface.js";
+import { UsStockStrategy } from "./usstock-strategy.js";
 
 type StrategyName = "fund" | "usstock";
 
@@ -16,8 +16,6 @@ export class StrategyFactory {
         return new FundStrategy();
       case "usstock":
         return new UsStockStrategy();
-      default:
-        throw new Error(`不明な戦略名: ${strategyName}`);
     }
   }
 }


### PR DESCRIPTION
## 概要

- `passkey-login.ts` / `password-login.ts` をそれぞれ `passkey/` / `password/` サブディレクトリに移動
- `auth.ts` を `password/authentication-code.ts` に移動
- `LoginMethodFactory` を導入し、ログイン方式の選択ロジックを呼び出し側から分離
- `StrategyFactory` の到達不能な `default` 節を削除
- `GEMINI.md` を削除
- devcontainer から Gemini CLI の設定を削除（拡張機能・マウント・インストールスクリプト・`.gitignore` エントリ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)