### PR TITLE
fix: entrypoint に register-matsui-passkey コマンドを追加

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ show_usage() {
     echo "Environment Variables:"
     echo "  APP_COMMAND          - 実行するコマンド"
     echo "                          sync-matsui-zaim"
+    echo "                          register-matsui-passkey"
     echo "                          zaim-cli"
     echo "                          login-google"
     echo "  APP_ARGS             - コマンドに渡すオプション/引数"
@@ -34,7 +35,7 @@ if [ -n "$PUID" ] || [ -n "$PGID" ]; then
 fi
 
 # VNCサーバーを起動する
-if [[ "$ENABLE_VNC" = "1" || "$APP_COMMAND" = "login-google" ]]; then
+if [[ "$ENABLE_VNC" = "1" || "$APP_COMMAND" = "login-google" || "$APP_COMMAND" = "register-matsui-passkey" ]]; then
     export DISPLAY=:1
     gosu node vncserver "$DISPLAY" -geometry "${VNC_GEOMETRY:-1280x960}" -SecurityTypes None
 fi
@@ -45,6 +46,9 @@ eval "set -- $APP_ARGS"
 case "$APP_COMMAND" in
     "sync-matsui-zaim")
         exec gosu node ./dist/commands/sync-matsui-zaim.js "$@"
+        ;;
+    "register-matsui-passkey")
+        exec gosu node ./dist/commands/register-matsui-passkey.js "$@"
         ;;
     "zaim-cli")
         exec gosu node ./dist/commands/zaim/index.js "$@"
@@ -57,7 +61,7 @@ case "$APP_COMMAND" in
         ;;
     *)
         echo "Error: Unknown command '$APP_COMMAND'"
-        echo "Valid commands: sync-matsui-zaim, zaim-cli, login-google"
+        echo "Valid commands: sync-matsui-zaim, register-matsui-passkey, zaim-cli, login-google"
         echo ""
         show_usage
         exit 1


### PR DESCRIPTION
## Summary

- `entrypoint.sh` に `register-matsui-passkey` のケースが存在せず、README 記載の手順通りに実行してもエラー終了していた問題を修正
- VNC 自動起動条件に `register-matsui-passkey` を追加（パスキー登録はヘッドレス不可のため）
- `show_usage` およびエラーメッセージのコマンド一覧にも追記

## Test plan

- [ ] `APP_COMMAND='register-matsui-passkey'` で `*` ケースのエラーにならず起動することを確認
- [ ] VNC が自動起動することを確認
- [x] `shellcheck` がクリアであることを確認（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)