### PR TITLE
feat: 米国株余力（usstock-power）戦略を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## 概要
 
-松井証券の資産状況（投資信託・米国株）を Zaim に同期するコマンドラインアプリケーションです。
+松井証券の資産状況を Zaim に同期するコマンドラインアプリケーションです。
 Zaim には松井証券の連携があるものの、[松井証券の電話番号認証導入によって自動的な同期ができない](https://content.zaim.net/questions/show/1125)という背景があります。
 
 このコマンドラインアプリケーションでは松井証券にログインして資産状況を取得し、そのデータを Zaim API を通して記録するものです。
@@ -83,27 +83,37 @@ docker compose run --rm -e APP_COMMAND='zaim-cli' -e APP_ARGS='auth setup-token'
   "name": "NISA",   // 任意の名前
   "enabled": true,  // 無効化したい場合は false にする
   "matsui": {
-    "type": "fund", // "fund" (投資信託) または "usstock" (米国株)
-    "accountName": "NISA口座(積立)" // 下記 (A) を参照
+    "type": "fund", // 下記 (A) を参照
+    "accountName": "NISA口座(積立)" // 下記 (B) を参照
   },
   "zaim": {
-    "accountId": "12345678",      // 下記 (B) を参照
-    "categoryId": "12345678"      // 下記 (C) を参照
+    "accountId": "12345678",      // 下記 (C) を参照
+    "categoryId": "12345678"      // 下記 (D) を参照
   }
 }
 ```
 
-#### (A) `matsui.accountName`
+#### (A) `matsui.type`
+
+同期する資産の種別を指定するもの。
+
+| 値 | 対象 | 記録内容 |
+|---|---|---|
+| `fund` | 投資信託 | 評価額合計 |
+| `usstock` | 米国株 | 株式時価総額合計（円換算） |
+| `usstock-power` | 米国株余力 | 米国株口座の使用可能現金合計（円建て + ドル建てをリアルタイムレートで円換算した値） |
+
+#### (B) `matsui.accountName`
 
 この値は同期対象の口座を指定するもの。
 
 - **投資信託 (`type: "fund"`) の場合**:
   - 松井証券の投資信託残高照会ページにアクセスし、全保有銘柄の表にある「口座区分」列の値を設定する
   - 例: `"NISA口座(積立)"`、`"特定口座"`
-- **米国株 (`type: "usstock"`) の場合**:
-  - 任意の文字列を設定する（米国株のデータ取得にはこの項目を利用しない）
+- **米国株・米国株余力 (`type: "usstock"` / `"usstock-power"`) の場合**:
+  - 任意の文字列を設定する（データ取得にはこの項目を利用しない）
 
-#### (B) `zaim.accountId`
+#### (C) `zaim.accountId`
 
 この値は同期先の Zaim の口座 ID を指定するもの。
 下記コマンドを実行して口座 ID 一覧を取得し、記録先の口座 ID を設定する。
@@ -113,7 +123,7 @@ docker compose run --rm -e APP_COMMAND='zaim-cli' -e APP_ARGS='auth setup-token'
 docker compose run --rm -e APP_COMMAND='zaim-cli' -e APP_ARGS='account list' app
 ```
 
-#### (C) `zaim.categoryId`
+#### (D) `zaim.categoryId`
 
 この値は同期先の Zaim の収入カテゴリ ID を指定するもの。
 下記コマンドを実行して収入カテゴリ ID 一覧を取得し、記録に利用するカテゴリ ID を設定する。

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 const { CONFIG_FILE } = process.env;
 
-const StrategyTypeSchema = z.enum(["fund", "usstock"]);
+const StrategyTypeSchema = z.enum(["fund", "usstock", "usstock-power"]);
 export type StrategyType = z.infer<typeof StrategyTypeSchema>;
 
 // Zodスキーマ定義
@@ -36,7 +36,7 @@ export const AppConfigSchema = z
     {
       // 松井証券の異なる口座の残高を同じZaimの口座に記録することは許可しない
       message: "Duplicate zaim.accountId values are not allowed",
-    }
+    },
   );
 
 // 型定義（Zodスキーマから自動生成）

--- a/src/modules/matsui/page.ts
+++ b/src/modules/matsui/page.ts
@@ -69,6 +69,13 @@ export class MatsuiPage {
   }
 
   /**
+   * 米国株用サイトの余力情報ページURL
+   */
+  static get usStockAssetPower(): string {
+    return this.getFullUrl(this.MATSUI_USSTOCK_BASE_URL, "/web/#/equity/asset-info/power");
+  }
+
+  /**
    * 米国株用サイトのお知らせページURL
    */
   static get usStockNotify(): string {

--- a/src/modules/matsui/strategies/index.ts
+++ b/src/modules/matsui/strategies/index.ts
@@ -1,8 +1,8 @@
+import type { StrategyType } from "../../config.js";
 import { FundStrategy } from "./fund-strategy.js";
 import type { AssetScrapingStrategy } from "./strategy-interface.js";
+import { UsStockPowerStrategy } from "./usstock-power-strategy.js";
 import { UsStockStrategy } from "./usstock-strategy.js";
-
-type StrategyName = "fund" | "usstock";
 
 export class StrategyFactory {
   /**
@@ -10,12 +10,14 @@ export class StrategyFactory {
    * @param strategyName 戦略名
    * @returns スクレイピング戦略のインスタンス
    */
-  static create(strategyName: StrategyName): AssetScrapingStrategy<unknown> {
+  static create(strategyName: StrategyType): AssetScrapingStrategy<unknown> {
     switch (strategyName) {
       case "fund":
         return new FundStrategy();
       case "usstock":
         return new UsStockStrategy();
+      case "usstock-power":
+        return new UsStockPowerStrategy();
     }
   }
 }

--- a/src/modules/matsui/strategies/usstock-power-strategy.ts
+++ b/src/modules/matsui/strategies/usstock-power-strategy.ts
@@ -1,0 +1,75 @@
+import type { Page } from "playwright";
+import type { UsStockPowerAsset } from "../../../types/matsui.js";
+import { logger } from "../../logger.js";
+import { parseNumber } from "../../utils.js";
+import { MatsuiPage } from "../page.js";
+import type { AssetScrapingStrategy } from "./strategy-interface.js";
+import { openUsStockTab } from "./usstock-utils.js";
+
+/**
+ * 米国株口座の使用可能現金（余力）をスクレイピングする戦略。
+ * 円建て現金とドル建て現金を取得し、ドル分をリアルタイムの米ドル/円レートで円換算して合計する。
+ */
+export class UsStockPowerStrategy implements AssetScrapingStrategy<UsStockPowerAsset> {
+  async prepareTargetPage(page: Page): Promise<Page> {
+    const newPage = await openUsStockTab(page);
+
+    await newPage.goto(MatsuiPage.usStockAssetPower);
+    await newPage.waitForLoadState("networkidle");
+    logger.info("米国株の余力情報ページに遷移しました。");
+
+    await newPage
+      .locator(".panel-color")
+      .filter({ has: newPage.locator(".panel-color-header", { hasText: "現物買付余力" }) })
+      .locator("table.asset-table")
+      .first()
+      .waitFor({ state: "visible", timeout: 30000 });
+
+    return newPage;
+  }
+
+  async scrapeAssets(page: Page): Promise<UsStockPowerAsset> {
+    const powerPanel = page.locator(".panel-color").filter({
+      has: page.locator(".panel-color-header", { hasText: "現物買付余力" }),
+    });
+
+    // 米国株口座の使用可能現金(円)
+    const jpyRow = powerPanel.locator("tr").filter({
+      has: page.locator("th.subtitle-cell", { hasText: "米国株口座の使用可能現金(円)" }),
+    });
+    const jpyText = await jpyRow.locator("td.value-cell").innerText();
+    const jpyCash = parseNumber(jpyText.replace(/円/g, ""));
+    if (jpyCash === undefined) {
+      throw new Error("米国株口座の使用可能現金(円)を取得できませんでした。");
+    }
+    logger.info(`米国株口座の使用可能現金(円): ${jpyCash}円`);
+
+    // 米国株口座の使用可能現金(ドル)
+    const usdRow = powerPanel.locator("tr").filter({
+      has: page.locator("th.subtitle-cell", { hasText: "米国株口座の使用可能現金(ドル)" }),
+    });
+    const usdText = await usdRow.locator("td.value-cell").innerText();
+    const usdCash = parseNumber(usdText.replace(/ドル/g, ""));
+    if (usdCash === undefined) {
+      throw new Error("米国株口座の使用可能現金(ドル)を取得できませんでした。");
+    }
+    logger.info(`米国株口座の使用可能現金(ドル): ${usdCash}ドル`);
+
+    // 米ドル/円レート（ページヘッダのリアルタイム表示から取得）
+    const rateElement = page.locator('[data-symbol="*@FX@USD/JPY@E@MarketInfoFull"]');
+    await rateElement.waitFor({ state: "visible", timeout: 10000 });
+    const rateText = await rateElement.innerText();
+    const rateMatch = rateText.match(/米ドル\/円\s*([\d,.]+)/);
+    const usdJpyRate = rateMatch?.[1] !== undefined ? parseNumber(rateMatch[1]) : undefined;
+
+    if (usdJpyRate === undefined) {
+      throw new Error("米ドル/円の為替レートを取得できませんでした。");
+    }
+    logger.info(`米ドル/円レート: ${usdJpyRate}`);
+
+    const totalBuyingPower = Math.round(jpyCash + usdCash * usdJpyRate);
+    logger.info(`米国株口座の使用可能現金合計（円換算）: ${totalBuyingPower}円`);
+
+    return { totalBuyingPower };
+  }
+}

--- a/src/modules/matsui/strategies/usstock-strategy.ts
+++ b/src/modules/matsui/strategies/usstock-strategy.ts
@@ -4,76 +4,14 @@ import { logger } from "../../logger.js";
 import { parseNumber } from "../../utils.js";
 import { MatsuiPage } from "../page.js";
 import type { AssetScrapingStrategy } from "./strategy-interface.js";
+import { openUsStockTab } from "./usstock-utils.js";
 
 /**
  * 米国株の資産データをスクレイピングする戦略
  */
 export class UsStockStrategy implements AssetScrapingStrategy<UsStockAsset> {
   async prepareTargetPage(page: Page): Promise<Page> {
-    await page.goto(MatsuiPage.tradeMemberHome);
-
-    // ヘッダの「米国株」メニューから辿るとブラウザの実行環境起因でエラー画面になってしまうため、資産状況ページから辿る。
-
-    // 資産状況ページに遷移
-    const assetStatusLink = page.locator('[data-page="asset-status-top"]');
-    await assetStatusLink.click();
-    logger.info("資産状況ページに遷移しました。");
-
-    // 資産状況一覧ページに遷移
-    const assetStatusListButton = page.locator(".btn-menu-asset-status-list:visible").first();
-    await assetStatusListButton.waitFor({ state: "visible", timeout: 10000 });
-    await assetStatusListButton.click();
-    logger.info("資産状況一覧ページに遷移しました。");
-
-    // 米国株式時価総額のリンクをクリックして預り残高一覧ページに遷移
-    const usStockMarketValueLink = page.locator("a").filter({ hasText: "米国株式時価総額" });
-    await usStockMarketValueLink.waitFor({ state: "visible", timeout: 10000 });
-    await usStockMarketValueLink.click();
-    logger.info("米国株式時価総額リンクをクリックしました。");
-
-    // iframe (#net-stock-contents) が読み込まれるまで待機
-    const iframe = page.frameLocator("#net-stock-contents");
-    logger.info("iframeの読み込みを待機中...");
-
-    // iframe内の入れ子になったframe (name="CT") を取得
-    const ctFrame = iframe.frameLocator('frame[name="CT"]');
-    logger.info("CTフレームを取得しました。");
-
-    // 「米国株サイト」のリンクをクリック
-    const usStockLink = ctFrame.locator("a").filter({ hasText: "米国株サイト" });
-    await usStockLink.waitFor({ state: "visible", timeout: 10000 });
-    await usStockLink.click();
-    logger.info("「米国株サイト」リンクをクリックしました。");
-
-    // frame内の起動ボタン (name="kidouButton"のimg要素の親a要素) を取得
-    const launchButton = ctFrame.locator('a:has(img[name="kidouButton"])');
-    await launchButton.waitFor({ state: "visible", timeout: 30000 });
-    logger.info("起動ボタンが表示されました。");
-
-    // 起動ボタンをクリックして新しいタブが開くのを待つ
-    const [newPage] = await Promise.all([
-      page.context().waitForEvent("page"),
-      launchButton.click(),
-    ]);
-    logger.info("米国株用サイトの起動ボタンをクリックしました。");
-
-    await newPage.waitForLoadState("networkidle");
-    logger.info("米国株用サイトが起動しました。");
-
-    // お客様へのご連絡ページが表示されるかを待機（タイムアウトあり）
-    const notificationTitle = newPage.locator("text=お客様へのご連絡");
-    const isNotificationVisible = await notificationTitle
-      .waitFor({ state: "visible", timeout: 5000 })
-      .then(() => true)
-      .catch(() => false);
-
-    // お客様へのご連絡表示が出た場合は「あとで確認」ボタンをクリック
-    if (isNotificationVisible) {
-      const laterButton = newPage.locator("div.btn").filter({ hasText: "あとで確認" });
-      await laterButton.click();
-      logger.info("「あとで確認」ボタンをクリックしました。");
-      await newPage.waitForLoadState("networkidle");
-    }
+    const newPage = await openUsStockTab(page);
 
     // 米国株の評価額を表示するページに遷移
     await newPage.goto(MatsuiPage.usStockPosition);

--- a/src/modules/matsui/strategies/usstock-utils.ts
+++ b/src/modules/matsui/strategies/usstock-utils.ts
@@ -1,0 +1,63 @@
+import type { Page } from "playwright";
+import { logger } from "../../logger.js";
+import { MatsuiPage } from "../page.js";
+
+/**
+ * 松井証券トップから米国株サイトの新タブを開いて返す。
+ * iframe経由のナビゲーションを UsStockStrategy と UsStockPowerStrategy で共用する。
+ */
+export async function openUsStockTab(page: Page): Promise<Page> {
+  await page.goto(MatsuiPage.tradeMemberHome);
+
+  // ヘッダの「米国株」メニューから辿るとブラウザの実行環境起因でエラー画面になってしまうため、資産状況ページから辿る。
+
+  const assetStatusLink = page.locator('[data-page="asset-status-top"]');
+  await assetStatusLink.click();
+  logger.info("資産状況ページに遷移しました。");
+
+  const assetStatusListButton = page.locator(".btn-menu-asset-status-list:visible").first();
+  await assetStatusListButton.waitFor({ state: "visible", timeout: 10000 });
+  await assetStatusListButton.click();
+  logger.info("資産状況一覧ページに遷移しました。");
+
+  const usStockMarketValueLink = page.locator("a").filter({ hasText: "米国株式時価総額" });
+  await usStockMarketValueLink.waitFor({ state: "visible", timeout: 10000 });
+  await usStockMarketValueLink.click();
+  logger.info("米国株式時価総額リンクをクリックしました。");
+
+  const iframe = page.frameLocator("#net-stock-contents");
+  logger.info("iframeの読み込みを待機中...");
+
+  const ctFrame = iframe.frameLocator('frame[name="CT"]');
+  logger.info("CTフレームを取得しました。");
+
+  const usStockLink = ctFrame.locator("a").filter({ hasText: "米国株サイト" });
+  await usStockLink.waitFor({ state: "visible", timeout: 10000 });
+  await usStockLink.click();
+  logger.info("「米国株サイト」リンクをクリックしました。");
+
+  const launchButton = ctFrame.locator('a:has(img[name="kidouButton"])');
+  await launchButton.waitFor({ state: "visible", timeout: 30000 });
+  logger.info("起動ボタンが表示されました。");
+
+  const [newPage] = await Promise.all([page.context().waitForEvent("page"), launchButton.click()]);
+  logger.info("米国株用サイトの起動ボタンをクリックしました。");
+
+  await newPage.waitForLoadState("networkidle");
+  logger.info("米国株用サイトが起動しました。");
+
+  const notificationTitle = newPage.locator("text=お客様へのご連絡");
+  const isNotificationVisible = await notificationTitle
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (isNotificationVisible) {
+    const laterButton = newPage.locator("div.btn").filter({ hasText: "あとで確認" });
+    await laterButton.click();
+    logger.info("「あとで確認」ボタンをクリックしました。");
+    await newPage.waitForLoadState("networkidle");
+  }
+
+  return newPage;
+}

--- a/src/modules/sync/sync-service.ts
+++ b/src/modules/sync/sync-service.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import fs from "fs";
 import path from "path";
 import type { Page } from "playwright";
+import type { Position, UsStockAsset, UsStockPowerAsset } from "../../types/matsui.js";
 import type { AccountConfig, AppConfig, MatsuiConfig, StrategyType } from "../config.js";
 import { logger } from "../logger.js";
 import type { MatsuiLoginMethod } from "../matsui/login-methods/login-method.js";
@@ -27,7 +28,7 @@ export class MatsuiZaimSyncService {
     private scraper: MatsuiScraper,
     private loginMethod: MatsuiLoginMethod,
     private totalAmountRepo: TotalAmountRepository,
-    private zaimClient: Zaim
+    private zaimClient: Zaim,
   ) {}
 
   /**
@@ -50,7 +51,7 @@ export class MatsuiZaimSyncService {
 
       // 各戦略を実行してデータ取得
       logger.info("資産評価額を取得します。");
-      const scrapedDataMap = new Map<StrategyType, any>();
+      const scrapedDataMap = new Map<StrategyType, unknown>();
 
       this.scraper.setLoginMethod(this.loginMethod);
       await this.scraper.authenticate();
@@ -129,23 +130,29 @@ export class MatsuiZaimSyncService {
    * @param matsuiConfig 松井証券の設定
    * @returns 評価額
    */
-  private extractAmount(data: any, matsuiConfig: MatsuiConfig): number {
-    // 戦略によって構造が異なる場合はここで吸収
+  private extractAmount(data: unknown, matsuiConfig: MatsuiConfig): number {
     switch (matsuiConfig.type) {
       case "fund": {
-        // fund戦略: details[accountName].評価額を参照
-        const value = data.details?.[matsuiConfig.accountName]?.評価額;
+        const position = data as Position;
+        const value = position.details?.[matsuiConfig.accountName]?.評価額;
         if (typeof value !== "number") {
           throw new Error(`${matsuiConfig.accountName}の評価額を取得できませんでした`);
         }
         return value;
       }
       case "usstock": {
-        // usstock戦略: totalAmountフィールドを直接参照
-        if (typeof data.totalAmount !== "number") {
+        const asset = data as UsStockAsset;
+        if (typeof asset.totalAmount !== "number") {
           throw new Error(`${matsuiConfig.accountName}の評価額を取得できませんでした`);
         }
-        return data.totalAmount;
+        return asset.totalAmount;
+      }
+      case "usstock-power": {
+        const asset = data as UsStockPowerAsset;
+        if (typeof asset.totalBuyingPower !== "number") {
+          throw new Error(`${matsuiConfig.accountName}の現物買付余力を取得できませんでした`);
+        }
+        return asset.totalBuyingPower;
       }
       default:
         throw new Error(`未対応の戦略タイプです: ${matsuiConfig.type}`);
@@ -162,13 +169,13 @@ export class MatsuiZaimSyncService {
   private async captureErrorContext(
     page: Page | null,
     error: Error,
-    context: { strategyType?: string }
+    context: { strategyType?: string },
   ): Promise<void> {
     try {
       // ERROR_LOG_DIR が未設定の場合はスキップ
       if (!ERROR_LOG_DIR) {
         logger.warn(
-          "ERROR_LOG_DIR が設定されていないため、エラーコンテキストのキャプチャをスキップします。"
+          "ERROR_LOG_DIR が設定されていないため、エラーコンテキストのキャプチャをスキップします。",
         );
         return;
       }
@@ -176,7 +183,7 @@ export class MatsuiZaimSyncService {
       // ページがnullの場合はメタデータのみ保存
       if (!page) {
         logger.warn(
-          "ページオブジェクトが取得できないため、スクリーンショットとHTMLのキャプチャをスキップします。"
+          "ページオブジェクトが取得できないため、スクリーンショットとHTMLのキャプチャをスキップします。",
         );
       }
 
@@ -239,15 +246,15 @@ export class MatsuiZaimSyncService {
     account: AccountConfig,
     currentAmount: number,
     lastTotalAmounts: LastTotalAmount[],
-    dryRun: boolean
+    dryRun: boolean,
   ): Promise<void> {
     let lastTotalAmountItem = lastTotalAmounts.find(
-      (item) => item.accountId === account.zaim.accountId
+      (item) => item.accountId === account.zaim.accountId,
     );
 
     if (typeof lastTotalAmountItem === "undefined") {
       logger.info(
-        `${account.name}の前回総額データがありません。初回実行時は前回総額を0として続行します。`
+        `${account.name}の前回総額データがありません。初回実行時は前回総額を0として続行します。`,
       );
       lastTotalAmountItem = {
         amount: 0,

--- a/src/types/matsui.ts
+++ b/src/types/matsui.ts
@@ -37,3 +37,14 @@ export interface UsStockAsset {
    */
   dailyChange: number;
 }
+
+/**
+ * 米国株の余力データ（米国株口座の使用可能現金を円換算した合計）
+ */
+export interface UsStockPowerAsset {
+  /**
+   * 米国株口座の使用可能現金合計（円換算）
+   * = 使用可能現金(円) + 使用可能現金(ドル) × 米ドル/円レート（四捨五入）
+   */
+  totalBuyingPower: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,7 @@
     "skipLibCheck": true,
   },
   "exclude": [
+    "dist",
     "vitest.config.ts",
     "**/*.test.ts"
   ]


### PR DESCRIPTION
## Summary

- 米国株口座の使用可能現金（円建て＋ドル建て×リアルタイムレート）を Zaim に同期する新戦略 `usstock-power` を追加
- `UsStockStrategy` と共用するナビゲーションロジックを `usstock-utils.ts` に抽出

## Test plan

- [x] `usstock-power` を設定した状態で `sync` コマンドを実行し、Zaim に正しい金額が記録されることを確認
- [ ] 為替レートが取得できない場合にエラーが発生することを確認
- [x] 既存の `fund` / `usstock` 戦略が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)