### PR TITLE
chore: GitHub Actionsのアクションバージョンをハッシュで固定

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -15,13 +15,13 @@ jobs:
       tag: ${{ steps.tagpr.outputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Run tagpr
         id: tagpr
-        uses: Songmu/tagpr@v1
+        uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,16 +38,16 @@ jobs:
       REGISTRY: ghcr.io
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -79,7 +79,7 @@ jobs:
           sbom: true
 
       - name: Attest build provenance
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -94,7 +94,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Publish release
         run: gh release edit "$TAG_NAME" --draft=false --latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -42,4 +42,4 @@ jobs:
 
       - name: Report Coverage
         if: always()
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0


### PR DESCRIPTION
## Summary

- `.github/workflows/tagpr.yml` および `.github/workflows/test.yml` 内の全アクション参照をタグ指定からコミットハッシュ固定に変更
- サプライチェーン攻撃対策として、タグが書き換えられても影響を受けないようにする

## 変更対象アクション

| アクション | 変更前 | 変更後 |
|---|---|---|
| `actions/checkout` | `v6` | `df4cb1c` (v6.0.3) |
| `actions/setup-node` | `v6` | `48b55a0` (v6.4.0) |
| `actions/attest` | `v4` | `59d8942` (v4.1.0) |
| `Songmu/tagpr` | `v1` | `e84001b` (v1.20.0) |
| `docker/setup-qemu-action` | `v4` | `06116385` (v4.1.0) |
| `docker/setup-buildx-action` | `v4` | `d7f5e7f` (v4.1.0) |
| `docker/login-action` | `v4` | `650006c` (v4.2.0) |
| `docker/metadata-action` | `v6` | `80c7e94` (v6.1.0) |
| `docker/build-push-action` | `v7` | `f9f3042` (v7.2.0) |
| `davelosert/vitest-coverage-report-action` | `v2` | `02f3c2e` (v2.12.0) |

## Test plan

- [x] CI が正常に通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)