### PR TITLE
ci: docker ジョブを github-builder 再利用ワークフローに移行しビルドキャッシュを最適化

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -28,62 +28,29 @@ jobs:
   docker:
     needs: tagpr
     if: needs.tagpr.outputs.tag != ''
-    runs-on: ubuntu-24.04
+    uses: docker/github-builder/.github/workflows/build.yml@17bd7d64200cae4ba58ffc099934e8012ae320f2 # v1.10.0
     permissions:
       contents: read
       packages: write
       id-token: write
-      attestations: write
-    env:
-      REGISTRY: ghcr.io
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY }}
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-mode: max
+      sbom: true
+      meta-images: ghcr.io/${{ github.repository }}
+      meta-tags: |
+        type=semver,pattern={{version}},value=${{ needs.tagpr.outputs.tag }}
+        type=semver,pattern={{major}}.{{minor}},value=${{ needs.tagpr.outputs.tag }}
+        type=semver,pattern={{major}},value=${{ needs.tagpr.outputs.tag }}
+        type=raw,value=latest,enable={{is_default_branch}}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.tagpr.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.tagpr.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ needs.tagpr.outputs.tag }}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push Docker image
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: mode=max
-          sbom: true
-
-      - name: Attest build provenance
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
 
   publish-release:
     needs: [tagpr, docker]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ FROM node:22-bookworm-slim AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.json ./
+
+RUN npm ci --include=dev --ignore-scripts
+
 COPY src ./src
 
-RUN npm ci --include=dev --ignore-scripts && \
-    npm run build
+RUN npm run build
 
 FROM node:22-bookworm-slim
 
@@ -27,7 +29,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 RUN chown -R node:node .
 
-COPY --from=builder --chown=node:node /app/dist ./dist
 COPY --from=builder --chown=node:node /app/package*.json ./
 
 USER node
@@ -48,6 +49,8 @@ RUN npx playwright install --with-deps --no-shell chromium && \
         /ms-playwright/ffmpeg* \
         /home/node/.npm/_logs/* && \
     chown -R node:node /home/node
+
+COPY --from=builder --chown=node:node /app/dist ./dist
 
 COPY --chmod=755 entrypoint.sh /
 


### PR DESCRIPTION
## Summary

- `docker` ジョブを `docker/github-builder` の再利用可能ワークフロー (`build.yml`) に移行し、CI設定をシンプル化
- Dockerfile のレイヤー順序を整理し、`npm ci` を依存関係インストール専用のレイヤーに分離することでビルドキャッシュ効率を向上
- `dist` ファイルのコピーを Playwright インストール後に移動し、ソースコード変更時の不要な再ビルドを削減

## Test plan

- [ ] PR のCI (`docker` ジョブ) が正常に通過することを確認
- [x] `linux/amd64` と `linux/arm64` の両プラットフォームでイメージがビルドされることを確認
- [ ] `ghcr.io` にイメージが push されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)